### PR TITLE
Added GTM ID to config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-      - run: make build
+      - run: JEKYLL_ENV=production make build
       - run: make serve &
       - run: make test
       - persist_to_workspace:
@@ -32,9 +32,7 @@ jobs:
   deploy:
     docker:
       - image: circleci/python:3
-    environment:
-      - AWS_DEFAULT_REGION: us-west-2
-      - JEKYLL_ENV: production
+    environment: AWS_DEFAULT_REGION=us-west-2
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,9 @@ jobs:
   deploy:
     docker:
       - image: circleci/python:3
-    environment: AWS_DEFAULT_REGION=us-west-2
+    environment:
+      - AWS_DEFAULT_REGION: us-west-2
+      - JEKYLL_ENV: production
     steps:
       - checkout
       - attach_workspace:

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,8 @@ plugins:
 
 source: src
 
+google_analytics: GTM-P4DRZ9C
+
 permalink: pretty
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -30,5 +30,5 @@
   <link rel="stylesheet" href="{{
     "/assets/main.css" | relative_url
   }}" /> {% if site.google_analytics and jekyll.environment == 'production' %}
-  {% include analytics.html %} {% endif %}
+  {% include google-analytics.html %} {% endif %}
 </head>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -29,5 +29,6 @@
   ></script>
   <link rel="stylesheet" href="{{
     "/assets/main.css" | relative_url
-  }}" />
+  }}" /> {% if site.google_analytics and jekyll.environment == 'production' %}
+  {% include analytics.html %} {% endif %}
 </head>


### PR DESCRIPTION
closes #20 

@adborden I was reading a bit about this and wanted to check - does our CircleCI build automatically set the environment (for the `jekyll.environment == 'production'` check) when the app is deployed? 

Will using the same analytics ID as the current live openoakland.org conflict with the overall analytics at all? I doubt `beta.aws.openoakland.org` is getting much traffic so mostly curious. 