### PR TITLE
Remove the two wp content links that were causing html proofer errors

### DIFF
--- a/src/press.md
+++ b/src/press.md
@@ -82,9 +82,11 @@ _October 29, 2013 - The Sunlight Foundation, Rebecca Williams_
 _August 4, 2013 - The White House_  
 'This is the heart of civic hacking for me: building new solutions and processes to replace broken ones, sharing our lessons and our successes and allowing others to benefit from our knowledge, failures, and shared technology.'
 
-[**There's an app for that**](http://digital.bizjournals.com/launch.aspx?eid=487ba110-ea58-40b0-9b07-21be5f5f5672 "SF Business Times")  
+<!-- AL removed link -->
+
+[**There's an app for that**]( http://digital.bizjournals.com/launch.aspx?eid=487ba110-ea58-40b0-9b07-21be5f5f5672"SF Business Times")  
 _August 16, 2013 - San Francisco Business Times_  
-'OpenOakland.. brings together coders, designers, city staff and others to improve how Oakland's government serves its citizens.' [SFBusinessTimes8-16-2013 (PDF)](http://openoakland.org/wp-content/uploads/2012/11/SFBusinessTimes8-16-2013.pdf)
+'OpenOakland.. brings together coders, designers, city staff and others to improve how Oakland's government serves its citizens.'
 
 <!-- AL removed link -->
 

--- a/src/resources.md
+++ b/src/resources.md
@@ -13,7 +13,9 @@ Resources and guidance for brigades in the<span style="font-weight: 400;">Code f
 
 <a href="https://docs.google.com/document/d/1TtEWZ1-XY3WHJ9dU4KaMIjDx7wcFGw3lbM8O8iUt2Sw/" target="_blank" rel="noopener noreferrer">Code for America Memorandum of Understanding</a>
 
-<a href="http://openoakland.org/wp-content/uploads/2018/01/Open-Oakland-Relationship-Letter.pdf" target="_blank" rel="noopener noreferrer">Open Oakland Relationship Letter</a> (PDF)  
+<!-- AL removed link -->
+
+Open Oakland Relationship Letter (PDF)  
 Letter declaring OpenOakland's relationship with Code for America for 501(c)(3) status tax exemption.
 
 [Code for America website](https://www.codeforamerica.org)


### PR DESCRIPTION
There are still wp links in unpublished pages here that need to be removed and updated.