### PR TITLE
Create redirect to Eventbrite page for NDoCH 2019

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ source "https://rubygems.org"
 # Happy Jekylling!
 gem "jekyll", "~> 3.8.5"
 gem 'jekyll-seo-tag'
+gem 'jekyll-redirect-from'
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.12.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.15.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.6.1)
@@ -92,8 +94,9 @@ DEPENDENCIES
   html-proofer (~> 3.10)
   jekyll (~> 3.8.5)
   jekyll-feed (~> 0.6)
+  jekyll-redirect-from
   jekyll-seo-tag
   tzinfo-data
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ markdown: kramdown
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-redirect-from
 
 source: src
 header_pages:

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -2,7 +2,9 @@
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  {%- seo -%}
+  {% if page.redirect %}
+  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}" />
+  {% endif %} {%- seo -%}
   <link
     rel="stylesheet"
     href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"

--- a/src/_layouts/redirect.html
+++ b/src/_layouts/redirect.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+<h3 style="text-align: center">Redirecting you, one moment please...</h3>

--- a/src/nationalday.md
+++ b/src/nationalday.md
@@ -1,4 +1,4 @@
 ---
 title: National Day of Civic Hacking
-redirect_to: https://www.eventbrite.com/e/national-day-of-civic-hacking-2019-tickets-69928206147
+redirect_to: https://www.eventbrite.com/e/national-day-of-civic-hacking-2019-tickets-69928206147?aff=openoaklanddotorgredirect
 ---

--- a/src/nationalday.md
+++ b/src/nationalday.md
@@ -1,0 +1,4 @@
+---
+title: National Day of Civic Hacking
+redirect_to: https://www.eventbrite.com/e/national-day-of-civic-hacking-2019-tickets-69928206147
+---


### PR DESCRIPTION
This page will show briefly when you go to `openoakland.org/nationalday`:

<img width="878" alt="Screen Shot 2019-08-20 at 11 29 47 PM" src="https://user-images.githubusercontent.com/28023047/63408132-276c3800-c3a3-11e9-8d1f-ae7c7a887beb.png">
