### PR TITLE
Disable external link checks by html proofer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ setup:
 	bundle install
 
 test:
-	bundle exec htmlproofer --check-html _site --url-ignore "/adoptadrainoakland.com/,/www.ckan.org/,/oaklandwiki.org/,/theatlanticcities.com/"
+	bundle exec htmlproofer --check-html _site --disable-external
 
 
 .PHONY: build serve setup test


### PR DESCRIPTION
Our builds keep breaking because external links are sometimes broken, or having their own issues. This makes it so that our site updates don't rely on other sites being up.

Closes #49. 