### PR TITLE
Add newsletter signup link to openoakland.org

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -27,14 +27,15 @@
             href="https://www.twitter.com/{{
               site.twitter_username | cgi_escape | escape
             }}"
+            target="_blank"
           >
             <i class="fa fa-twitter"></i>
             <span>{{ site.twitter_username | escape }}</span></a
           >
           <br />
-          <a href="mailto:{{ site.email }}">
+          <a href="{{ '/newsletter' | relative_url }}" target="_blank">
             <i class="fa fa-envelope"></i>
-            <span>{{ site.email }}</span>
+            <span>Join our Newsletter</span>
           </a>
         </div>
       </div>

--- a/src/about-us.md
+++ b/src/about-us.md
@@ -22,3 +22,5 @@ Our organization is led by an elected steering committee and [bylaws](https://do
 A member from each [active project]({{ site.baseurl }}/projects/) team should also attend the Steering Committee meeting each month.
 It doesn't need to always be the same person, but it should be part of the core team. All OpenOakland members are welcome to sit in on leadership meetings. Responsibilities for each steering committee role is defined in the 
 [OpenOakland Steering Committee Bylaws](https://docs.google.com/document/d/1QR-fr1WnmXkZoVNmWnZ9drzfmaZoPkodEOx-PkExt94/).
+
+To contact the steering committee, email <a target="_blank" href="mailto:{{ site.email }}">{{ site.email }}</a>.

--- a/src/newsletter.md
+++ b/src/newsletter.md
@@ -1,0 +1,4 @@
+---
+title: OpenOakland Newsletter
+redirect_to: http://eepurl.com/db36wj
+---


### PR DESCRIPTION
Two commits to make it possible to sign up for the newsletter from OpenOakland:

1. Add a redirect from `openoakland.org/newsletter` to a new mailchimp register page.

2. Update the email link in the footer to take people to the newsletter signup, rather than just emailing `steering@openoakland.org`. I moved the email address to the "About Us" page so it's still there if someone wants to find it.