### PR TITLE
Update Councilmatic Link

### DIFF
--- a/src/_data/active_projects.yml
+++ b/src/_data/active_projects.yml
@@ -7,7 +7,7 @@
   description: This landing page is intended to be a portal for the 2020 Census administered by Alameda County. It will be accessible at locations where a computer or tablet is provided to the public and is intended to introduce people to the Census and offer information in their native language about why the Census is important to complete, as well as resources and guides on how to complete the Census. It is intended to be welcoming to people for whom English is not their first language.
 - name: Councilmatic
   image: councilmatic_300x118.png
-  link: http://councilmatic.aws.openoakland.org/pc/
+  link: https://oaklandcouncil.net/
   leader: Howard Mattis
   slack_id: C0M89GTRT
   slack_channel: councilmatic


### PR DESCRIPTION
I was trying to get to councilmatic to find some council meetings we could go to. Used the open oakland website and found it took me to the wrong place. This updates the link to the correct destination.