### PR TITLE
Add next Meetup event to homepage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,11 +43,22 @@ jobs:
 workflows:
   version: 2
   commit:
-    jobs:
+    jobs: &build_and_deploy_jobs
       - build
       - deploy:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
+
+  nightly_build:
+    jobs: *build_and_deploy_jobs
+    triggers:
+      - schedule:
+          # 13:00 UTC = 6:00 AM PDT
+          cron: "0 13 * * *"
           filters:
             branches:
               only:

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 3.8.5"
 gem 'jekyll-seo-tag'
 gem 'jekyll-redirect-from'
+gem 'hash-joiner'
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
     eventmachine (1.2.7)
     ffi (1.11.1)
     forwardable-extended (2.6.0)
+    hash-joiner (0.0.7)
+      safe_yaml
     html-proofer (3.11.1)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
@@ -91,6 +93,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  hash-joiner
   html-proofer (~> 3.10)
   jekyll (~> 3.8.5)
   jekyll-feed (~> 0.6)

--- a/_config.yml
+++ b/_config.yml
@@ -51,3 +51,6 @@ permalink: pretty
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
+jekyll_get:
+  - data: events
+    json: https://api.meetup.com/OpenOakland/events?&page=2

--- a/src/_plugins/jekyll_get.rb
+++ b/src/_plugins/jekyll_get.rb
@@ -1,0 +1,40 @@
+require 'json'
+require 'hash-joiner'
+require 'open-uri'
+
+module JekyllGet
+  class Generator < Jekyll::Generator
+    safe true
+    priority :highest
+
+    def generate(site)
+      config = site.config['jekyll_get']
+      if !config
+        return
+      end
+      if !config.kind_of?(Array)
+        config = [config]
+      end
+      config.each do |d|
+        begin
+          target = site.data[d['data']]
+          source = JSON.load(open(d['json']))
+          if target
+            HashJoiner.deep_merge target, source
+          else
+            site.data[d['data']] = source
+          end
+          if d['cache']
+            data_source = (site.config['data_source'] || '_data')
+            path = "#{data_source}/#{d['data']}.json"
+            open(path, 'wb') do |file|
+              file << JSON.generate(site.data[d['data']])
+            end
+          end
+        rescue
+          next
+        end
+      end
+    end
+  end
+end

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -70,36 +70,38 @@ main {
   border-top: 1px solid $grey-color-light;
 }
 
+// bootstrap overrides
+.btn-primary {
+  background-color: $brand-color;
+  border-color: $brand-color;
+
+  &:hover {
+    background-color: darken($brand-color, 10%);
+    border-color: darken($brand-color, 10%);
+  }
+
+  &:active {
+    background-color: darken($brand-color, 15%) !important;
+    border-color: darken($brand-color, 15%) !important;
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 .2rem lighten($brand-color, 20%) !important;
+  }
+}
+
 // OO custom styles
 .page-section {
   clear: both;
   margin-bottom: $spacing-unit * 2;
 }
 
-.landing-page-image {
-  display: inline-block;
-  max-width: 100px;
-  margin-right: 20px;
-}
+.home__event-card {
+  margin-bottom: $spacing-unit;
 
-.landing-page-photo {
-  clear: both;
-  float: right;
-  width: 100%;
-
-  @include media($tablet-up) {
-    margin-bottom: $spacing-unit * 2;
-    margin-left: $spacing-unit * 2;
-    width: 300px;
-  }
-
-  img {
-    margin-bottom: .5rem;
-    width: 100%;
-  }
-
-  figcaption {
-    font-size: .8rem;
+  .card-img {
+    height: 100%;
+    object-fit: cover;
   }
 }
 

--- a/src/index.md
+++ b/src/index.md
@@ -3,32 +3,71 @@ layout: home
 title: We are OpenOakland
 ---
 
-<h5>OpenOakland bridges <b>technology</b> and <b>community</b> for a thriving and equitable Oakland.</h5>
+<section class="row page-section">
+  <div class="col-sm-8">
+    <h5>OpenOakland bridges <b>technology</b> and <b>community</b> for a thriving and equitable Oakland.</h5>
+
+    <p>As part of the <a href="https://brigade.codeforamerica.org" target="_blank">Code for America Brigade network</a>, we are a welcoming and inclusive volunteer group of developers, designers, data geeks, and citizen activists who use creative technology to solve civic and social problems.</p>
+  </div>
+
+  <div class="col-sm-4">
+    <figure>
+      <img src="/assets/images/DayOfService2019.jpg" alt="Attendees of our 2019 Day of Service" width="100%"/>
+      <figcaption>OpenOakland members at our 2019 Day of Service event</figcaption>
+    </figure>
+  </div>
+</section>
 
 <section class="page-section">
-  <figure class="landing-page-photo">
-    <img src="/assets/images/DMVStrikeTeam.jpg" alt="OpenOakland members performing a user test of a government website." />
-    <figcaption>OpenOakland members performing a user test of a government website.</figcaption>
-  </figure>
-
-  <p>As part of the <a href="https://brigade.codeforamerica.org" target="_blank">Code for America Brigade network</a>, we are a welcoming and inclusive volunteer group of developers, designers, data geeks, and citizen activists who use creative technology to solve civic and social problems.</p>
-
-  <div class="landing-page-image">
-    <img class="img-fluid" alt="RSVP on Meetup" src="/assets/images/RSVP-on-meetup-300x200.png" />
+  <h2>Our Next Meeting</h2>
+  {% assign next_event = site.data.events[0] %}
+  <div class="card home__event-card">
+    <div class="row no-gutters">
+      <div class="col-md-4">
+        <img class="card-img" src="/assets/images/DMVStrikeTeam.jpg" alt="OpenOakland members performing a user test of a government website." />
+      </div>
+      <div class="col-md-8">
+        <div class="card-body">
+          <h3 class="card-title">
+            <a href="{{ next_event.link }}" target="_blank">{{ next_event.name }}</a>
+          </h3>
+          <p class="card-text">
+            {{ next_event.description | strip_html | truncatewords: 30 }}
+          </p>
+          <a href="{{ next_event.link }}" target="_blank" class="card-link btn btn-primary">RSVP on Meetup</a>
+        </div>
+      </div>
+      <div class="col-12 px-4 card-footer d-flex justify-content-between">
+        <span>
+        <i class="fa fa-calendar"></i> {{ next_event.local_date | date: "%A, %B %d, %Y" }}
+        </span>
+        <span>
+        <i class="fa fa-clock-o"></i> {{ next_event.local_time | date: "%l:%M %p" }}
+        </span>
+      </div>
+    </div>
   </div>
 
   <p>
-    We meet every Tuesday at 6:30pm at Oakland City Hall in Hearing Room 4. Food is provided. Join us by <a href="https://www.meetup.com/OpenOakland/">RSVPing on our Meetup page</a>.
+  All OpenOakland meetings are open the public, regardless of technical ability.
   </p>
+
+  <p>
+  We hope you'll join us! If you can't make this event, <a href="https://meetup.com/{{ event.group.urlname}}" target="_blank">check our Meetup group for our future events</a>. You'll find us most Tuesdays nights at Oakland City Hall in Hearing Room 4. Food is provided.
+  </p>
+
 </section>
 
-<section>
-  <figure class="landing-page-photo">
-    <img src="/assets/images/DayOfService2019.jpg" alt="Attendees of our 2019 Day of Service" />
-    <figcaption>OpenOakland members at our 2019 Day of Service event</figcaption>
-  </figure>
-  <div class="landing-page-image">
-      <img class="img-fluid" alt="RSVP on Meetup" src="/assets/images/OO-on-Slack-300x128.png" />
+<section class="row page-section">
+  <div class="col-12">
+    <h2>Join us in Slack</h2>
   </div>
-  <p>OpenOakland members primarily use Slack for all communication. Please fill out <a href="https://tinyurl.com/y722n6ul">this contact form</a> to get an invitation to our slack channel.</p>
+
+  <div class="col-8">
+    <p>OpenOakland members primarily use Slack for all communication. Please fill out <a href="https://tinyurl.com/y722n6ul">this contact form</a> to get an invitation to our slack channel.</p>
+  </div>
+
+  <div class="col-4">
+    <img class="img-fluid" alt="RSVP on Meetup" src="/assets/images/OO-on-Slack-300x128.png" width="100" />
+  </div>
 </section>


### PR DESCRIPTION
This commit steals from [Code for Chicago's website config][1] to use
the jekyll_get plugin to download the next event from our Meetup page.

The homepage is dramatically changed to accommodate the card: the
picture of people huddled around is repurposed as an event card photo,
bootstrap grid & card styles are used more prevalently, and some CSS
overrides to keep branding consistency are also included.


# screenshot
![image](https://user-images.githubusercontent.com/129120/68561160-39390680-03f9-11ea-99f1-d59ca4b2ede2.png)

[1]: https://github.com/Code-For-Chicago/code-for-chicago-jekyll/blob/1c58caea7843/_config.yml#L102-L104

