### PR TITLE
Remove NDoCH as an upcoming event.

### DIFF
--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -45,6 +45,9 @@ p {
 
 a {
   color: $brand-color;
+  &:hover {
+    color: darken($brand-color, 20%);
+  }
 }
 
 main {
@@ -86,7 +89,7 @@ main {
   }
 
   &:focus {
-    box-shadow: 0 0 0 .2rem lighten($brand-color, 20%) !important;
+    box-shadow: 0 0 0 0.2rem lighten($brand-color, 20%) !important;
   }
 }
 

--- a/src/calendar.md
+++ b/src/calendar.md
@@ -12,6 +12,8 @@ OpenOakland meets every Tuesday at Oakland City Hall. We welcome everyone to joi
 
 We encourage first-time attendees to join us during our **monthly New Member Onboarding** the last Tuesday night of the month.
 
-### Upcoming Events
+### Past Events
 
-**National Brigade Day of Action**  Saturday, September 21, 2019
+- [Open Data Day](https://www.meetup.com/OpenOakland/events/258831439/){:target="\_blank"} March 2, 2019
+- [Day of Service](https://www.eventbrite.com/e/openoakland-day-of-service-2019-tickets-59979544432){:target="\_blank"} May 11, 2019
+- [National Day of Civic Hacking](https://www.eventbrite.com/e/national-day-of-civic-hacking-2019-tickets-69928206147){:target="\_blank"} September 21, 2019


### PR DESCRIPTION
List our big events this year as Past Events. Also changes the color of links on hover, as the previous blue color didn't make sense to me.

### Screenshots

**Calendar:**
<img width="922" alt="Screen Shot 2019-11-10 at 9 45 44 PM" src="https://user-images.githubusercontent.com/28023047/68564053-617a3280-0404-11ea-9141-725c1550ccb2.png">

**Link hover:**
<img width="596" alt="Screen Shot 2019-11-10 at 9 46 36 PM" src="https://user-images.githubusercontent.com/28023047/68564130-94bcc180-0404-11ea-8025-04b3dfbc6236.png">