### PR TITLE
Use media query to shrink header logo in responsive views

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -3,7 +3,7 @@
     {%- assign default_paths = site.data.navigation | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
     <a class="navbar-brand" rel="author" href="{{ "/" | relative_url }}">
-      <img src="/assets/images/OpenOakland-logo.png" width="280" alt="OpenOakland Logo">
+      <img src="/assets/images/OpenOakland-logo.png" class="header-logo" alt="OpenOakland Logo">
     </a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -69,6 +69,13 @@ main {
   min-height: $spacing-unit * 1.865;
 }
 
+.header-logo {
+  width: 280px;
+  @media (max-width: $mobile-up) {
+    width: 200px;
+  }
+}
+
 .site-footer {
   border-top: 1px solid $grey-color-light;
 }


### PR DESCRIPTION
closes #65 

### Mobile screenshots
<img width="326" alt="Screen Shot 2019-11-12 at 8 50 06 PM" src="https://user-images.githubusercontent.com/28023047/68734474-4daf0780-058f-11ea-8d8a-104bc2a051a4.png">

### Desktop screenshots
<img width="920" alt="Screen Shot 2019-11-12 at 9 01 18 PM" src="https://user-images.githubusercontent.com/28023047/68734566-9e266500-058f-11ea-80e6-e89285765e33.png">


