### PR TITLE
move census LP to inactive projects, minor style change

### DIFF
--- a/src/_data/active_projects.yml
+++ b/src/_data/active_projects.yml
@@ -10,14 +10,6 @@
     learn more about the first all-digital census through these events, even
     finding locations where they can get assistance to complete the census.
     Residents can search for events based on date, location, and language.
-
-- name: Alameda County Census 2020 Landing Page
-  image:
-  link:
-  leader: Lydia Kats
-  slack_id: CJJ9B9A3S
-  slack_channel: census-projects
-  description: This landing page is intended to be a portal for the 2020 Census administered by Alameda County. It will be accessible at locations where a computer or tablet is provided to the public and is intended to introduce people to the Census and offer information in their native language about why the Census is important to complete, as well as resources and guides on how to complete the Census. It is intended to be welcoming to people for whom English is not their first language.
 - name: Councilmatic
   image: councilmatic_300x118.png
   link: https://oaklandcouncil.net/

--- a/src/_data/inactive_projects.yml
+++ b/src/_data/inactive_projects.yml
@@ -4,6 +4,13 @@
   established: 2011
   link: https://adoptadrainoakland.com
   description: Adopt a Drain is a platform for Oakland residents to volunteer to be responsible for keeping a nearby storm drain clear to decrease flooding from storms, protect water quality, and keep trash from storm drains and connected creeks and water bodies. Vigilant maintenance of the City’s storm drain infrastructure is important for reducing pollution in the Bay. Adopt a Drain was set up in partnership with [City of Oakland’s Public Works Agency](http://www2.oaklandnet.com/government/o/PWA/o/FE/s/ID/OAK024735#Drain).
+- name: Alameda County Census 2020 Landing Page
+  image:
+  link: https://llkats.github.io/dos-acccc/
+  leader: Lydia Kats
+  slack_id: CJJ9B9A3S
+  slack_channel: census-projects
+  description: This landing page is intended to be a portal for the 2020 Census administered by Alameda County. It will be accessible at locations where a computer or tablet is provided to the public and is intended to introduce people to the Census and offer information in their native language about why the Census is important to complete, as well as resources and guides on how to complete the Census. It is intended to be welcoming to people for whom English is not their first language.
 -
   name: CannaEquity.org
   image: cannaequity_300x199.png

--- a/src/_sass/wp.scss
+++ b/src/_sass/wp.scss
@@ -31,12 +31,7 @@
   clear: both;
   font-weight: bold;
   line-height: 1;
-  padding: 12px 0;
-}
-
-#projects h3 a,
-#projects h3 span {
-  padding-left: 12px;
+  padding: 12px;
 }
 
 .steeering-committee-image {


### PR DESCRIPTION
- Move the census landing page project to inactive projects.
- Adds a link to the github pages version of the site.

Bonus:
- Corrects misaligned padding for headers that break to two lines on narrow screens

### Mobile screenshots
Header padding fix
| Before | After |
|-|-|
| ![](https://user-images.githubusercontent.com/578156/84220735-63829d80-aa88-11ea-9252-0a85054d617c.png) | ![](https://user-images.githubusercontent.com/578156/84220842-acd2ed00-aa88-11ea-98d4-5388ad308c85.png) |

### Desktop screenshots
Census LP project now appears in inactive projects
<img width="829" alt="image" src="https://user-images.githubusercontent.com/578156/84220486-c1fb4c00-aa87-11ea-8e0c-4cbde21efb57.png">
