### PR TITLE
Add Relationship Letter Google doc share link

### DIFF
--- a/src/resources.md
+++ b/src/resources.md
@@ -13,7 +13,7 @@ This handbook is a guide on how to access all the resources that the Code for Am
 [Code for America Memorandum of Understanding](https://docs.google.com/document/d/1TtEWZ1-XY3WHJ9dU4KaMIjDx7wcFGw3lbM8O8iUt2Sw/){: target="_blank" rel="noopener noreferrer"}
 
 <!-- AL removed link -->
-Open Oakland Relationship Letter (PDF)  
+[Open Oakland Relationship Letter](https://drive.google.com/file/d/1i6BzWwVQHYSPD_Aa9HwqCpc8MEtpcqC2/view?usp=sharing){: target="_blank" rel="noopener noreferrer"} (PDF)
 Letter declaring OpenOakland's relationship with Code for America for 501(c)(3) status tax exemption.
 
 [Code for America website](https://www.codeforamerica.org)

--- a/src/resources.md
+++ b/src/resources.md
@@ -12,7 +12,6 @@ This handbook is a guide on how to access all the resources that the Code for Am
 
 [Code for America Memorandum of Understanding](https://docs.google.com/document/d/1TtEWZ1-XY3WHJ9dU4KaMIjDx7wcFGw3lbM8O8iUt2Sw/){: target="_blank" rel="noopener noreferrer"}
 
-<!-- AL removed link -->
 [Open Oakland Relationship Letter](https://drive.google.com/file/d/1i6BzWwVQHYSPD_Aa9HwqCpc8MEtpcqC2/view?usp=sharing){: target="_blank" rel="noopener noreferrer"} (PDF)
 Letter declaring OpenOakland's relationship with Code for America for 501(c)(3) status tax exemption.
 


### PR DESCRIPTION
closes #87

Fixes missing link to Relationship Letter, as share link to PDF stored on Google drive https://drive.google.com/file/d/1i6BzWwVQHYSPD_Aa9HwqCpc8MEtpcqC2/view?usp=sharing

This is maybe not the best way to attach this document, but the link was dead so it should be better than nothin'