### PR TITLE
Add docker-compose and Dockerfile for local dev

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -14,7 +14,7 @@ Please be familiar with the OpenOakland’s [Code of Conduct](https://github.com
 - [Ruby 2.5+](https://www.ruby-lang.org/en/)
 - [bundler](https://bundler.io/)
 
-### Setup
+### Setup (Local)
 
 Clone or fork the repository and navigate to the project folder.
 
@@ -33,6 +33,14 @@ Run some checks.
 Start a local server.
 
     $ make serve
+
+Open your web browser to [localhost:4000](http://localhost:4000/).
+
+### Setup (Docker)
+
+With [Docker](https://www.docker.com/) installed, navigate to the project folder and run:
+
+    $ make docker_serve
 
 Open your web browser to [localhost:4000](http://localhost:4000/).
 
@@ -101,7 +109,7 @@ Example project info YAML block:
 
 ## Testing
 
-- Run `make test` in your terminal before making a pull request.
+- Run `make test` in your terminal (or `make docker_test`) before making a pull request.
 
 ## Deployment
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2.7
+
+COPY . /code
+WORKDIR /code
+RUN make setup
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,17 @@ build:
 serve:
 	bundle exec jekyll serve
 
+docker_serve:
+	docker-compose up
+
 setup:
 	bundle install
 
 test:
 	bundle exec htmlproofer --check-html _site --disable-external
+
+docker_test:
+	docker-compose run --rm site make test
 
 
 .PHONY: build serve setup test

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ serve:
 	bundle exec jekyll serve
 
 docker_serve:
-	docker-compose up
+	docker-compose up --build
 
 setup:
 	bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "2.0"
+services:
+  site:
+    build: .
+    volumes:
+      - ".:/code"
+    ports:
+      - "4000:4000"
+    command: ["/usr/local/bin/bundle", "exec", "jekyll", "serve", "-H", "0.0.0.0"]


### PR DESCRIPTION
This PR doesn't address any currently open issues, but addresses the problem that @nickmora and I ran into when trying to run Jekyll locally.

This PR:
- adds the ability to run `jekyll` from Docker with a `docker-compose.yml` and a `Dockerfile`
- adds targets for the `Makefile` for `docker_serve` and `docker_test`
- adds documentation in the `contributing.md` for using the new Docker commands