### PR TITLE
Fix link styles and other minor things.

### DIFF
--- a/src/_includes/calendarEvent.html
+++ b/src/_includes/calendarEvent.html
@@ -8,7 +8,7 @@
       <h3 class="card-title">{% if calendar.title %}{{ calendar.title }}{% endif %}</h3>
       <h4 class="card-subtitle calendar-card-subtitle">{% if calendar.subtitleGuest %}{{ calendar.subtitleGuest }}{% endif %}</h4>
       <p class="card-text">{% if calendar.descriptionSentence %}{{ calendar.descriptionSentence }}{% endif %}</p>
-      {% if calendar.link %}<a href="{{ calendar.link }}" class="btn btn-primary btn-sm">{{ calendar.buttonText }}</a>{% endif %} {% if calendar.secondaryLink %}<a href="{{ calendar.secondaryLink }}" class="card-link calendar-card-link">{{ calendar.secondaryLinkText }}</a>{% endif %}
+      {% if calendar.link %}<a href="{{ calendar.link }}" class="btn btn-primary btn-sm">{{ calendar.buttonText }}</a>{% endif %} {% if calendar.secondaryLink %}<a href="{{ calendar.secondaryLink }}" class="card-link calendar-card-link brand-link">{{ calendar.secondaryLinkText }}</a>{% endif %}
     </div>
 
     <div class="card-footer text-muted">

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -65,10 +65,14 @@ ul {
 
 li {margin-top:1.1rem;}
 
-a {
-  color: $brand-color;
+a:not([class]),
+.brand-link {
+  color: darken($brand-color, 20%);
+  text-decoration: underline;
+
   &:hover {
-    color: darken($brand-color, 20%);
+    background-color: darken($brand-color, 20%);
+    color: white;
   }
 }
 

--- a/src/_sass/wp.scss
+++ b/src/_sass/wp.scss
@@ -44,8 +44,10 @@
     font-style: italic;
   }
 
-.calendar-card-link {
-  margin-left:.5rem;
+// Give the calendar-card-link left margin only if it's
+// the second child.
+.btn + .calendar-card-link {
+  margin-left: .5rem;
 }
 
 

--- a/src/donate.md
+++ b/src/donate.md
@@ -10,7 +10,7 @@ At OpenOakland, civic tech means helping communities understand and navigate loc
 Your generous gift will support our efforts to connect to all of Oakland through events and weekly meetings
 
 {: style="text-align: center"}
-[Donate Now!](https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Open%20Oakland&utm_source=OpenOakland%20site){:target="_blank" .btn style="background-color: #21b890; color: #ffffff;"}
+[Donate Now!](https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Open%20Oakland&utm_source=OpenOakland%20site){:target="_blank" .btn.btn-primary }
 
 ## Donations Provide
 - Resources for outreach activities and events


### PR DESCRIPTION
closes #66

This PR changes the default link style so it's more accessible. It makes the previous hover color the default color (giving a contrast ratio of 7.18 (the minimum for WCAG AA is 4.5) and it adds an underline so interactivity is not communicated with color alone (a requirement for [WCAG rule 1.4.1](https://www.w3.org/TR/WCAG21/#use-of-color)).

Hovering a link will add a background color and invert the text color (see video preview below).

https://user-images.githubusercontent.com/1066253/103952085-9f501500-50f4-11eb-8a77-dc2b0c982a97.mp4

This is a slight variation from what was recommended in the style guide, but I'm happy to use what was discussed there if folks prefer always having the background color. One concern I had was when links appear next to buttons, it might look a little odd if they already have a background color, for example:
<img width="457" alt="Screen Shot 2021-01-07 at 2 34 20 PM" src="https://user-images.githubusercontent.com/1066253/103952591-88f68900-50f5-11eb-830a-2e15214ff5c9.png">

Whereas with this PR I think they fit in a bit better:
<img width="418" alt="Screen Shot 2021-01-07 at 2 36 02 PM" src="https://user-images.githubusercontent.com/1066253/103952713-b6433700-50f5-11eb-92f1-54ef3dbfa622.png">

**A note on the implementation**

Changing the default `a` style had unexpected side effects throughout the site. For example, `.btn`, `.card-link`, and `.nav-link` elements started displaying underlines and different background-colors on hover.

I used a `a:not([class])` selector which essentially says "any anchor elements _without_ a `class` will get these default styles". So if you're just writing markdown and linking things then they'll get the new styles. In addition, I added a `.brand-link` class which can be used in places where you need to have a class on an anchor element. You can see how I added one of these to the `.calendar-card-link` element.

**Other minor fixes**

- Fixed an issue where calendar links had extra left margin if they were the only child
- Fixed an issue where the donate button did not have hover styles because it had inline styles overriding them

##### _If your PR changes the appearance of the site, please include desktop and mobile screenshots below_
### Mobile screenshots
![mobile-1](https://user-images.githubusercontent.com/1066253/103953489-18506c00-50f7-11eb-8b36-a620e3842499.png)

<br>

![mobile-2](https://user-images.githubusercontent.com/1066253/103953564-35853a80-50f7-11eb-8a11-e29fecc9bb16.png)


### Desktop screenshots
![desktop-1](https://user-images.githubusercontent.com/1066253/103953547-2ef6c300-50f7-11eb-9999-3bd8b434e68e.png)

<br>

![image](https://user-images.githubusercontent.com/1066253/103953647-5c437100-50f7-11eb-8ac3-4bdf3c21fb98.png)

