### PR TITLE
Add project filter dropdown

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -31,6 +31,9 @@
     integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
     crossorigin="anonymous"
   ></script>
+  {% for item in page.scripts %}
+  <script src="{{item}}" type="module"></script>
+  {% endfor %}
   <link rel="stylesheet" href="{{
     "/assets/main.css" | relative_url
   }}" />

--- a/src/_includes/project.html
+++ b/src/_includes/project.html
@@ -11,6 +11,9 @@
                 <span class="badge badge-{{ page.badges[status] }} ml-2">{{ status | capitalize }}</span>
               </h3>
             {% endif %}
+            {% if status == 'inactive' or status == 'decommissioned' %}
+              <p class="mt-0"><a class="text-small" href="#{{ status }}-projects">What does {{ status }} mean?</a></p>
+            {% endif %}
           </div>
 
           <div class="card-text">{% if project.description %}{{ project.description | smartify }}{% endif %}</div>

--- a/src/_includes/project.html
+++ b/src/_includes/project.html
@@ -1,12 +1,17 @@
-<div class="d-flex col-sm-12 cols-md-12">
-<div class="card projects" data-tags="{{ tags }}">
+<div class="d-flex">
+<div class="card projects" data-tags="{{ status }}">
 
   <div class="row no-gutters">
 
       <div class="col-md-8">
         <div class="card-body">
-
-          {% if project.name %}<h3 class="projects-h3">{{ project.name }}</h3>{% endif %}
+          <div>
+            {% if project.name %}
+              <h3 class="projects-h3">{{ project.name }} 
+                <span class="badge badge-{{ page.badges[status] }} ml-2">{{ status | capitalize }}</span>
+              </h3>
+            {% endif %}
+          </div>
 
           <div class="card-text">{% if project.description %}{{ project.description | smartify }}{% endif %}</div>
 

--- a/src/_includes/project.html
+++ b/src/_includes/project.html
@@ -1,5 +1,5 @@
 <div class="d-flex col-sm-12 cols-md-12">
-<div class="card projects">
+<div class="card projects" data-tags="{{ tags }}">
 
   <div class="row no-gutters">
 

--- a/src/_includes/project.html
+++ b/src/_includes/project.html
@@ -12,7 +12,7 @@
               </h3>
             {% endif %}
             {% if status == 'inactive' or status == 'decommissioned' %}
-              <p class="mt-0"><a class="text-small" href="#{{ status }}-projects">What does {{ status }} mean?</a></p>
+              <p class="mt-0"><a class="text-small brand-link" href="#{{ status }}-projects">What does {{ status }} mean?</a></p>
             {% endif %}
           </div>
 

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -172,3 +172,7 @@ main {
     margin-left: 0.5rem;
   }
 }
+
+.text-small {
+  font-size: $small-font-size;
+}

--- a/src/_sass/main.scss
+++ b/src/_sass/main.scss
@@ -163,3 +163,12 @@ main {
   width: 100%;
   height: 100%;
 }
+
+.project-filter__toolbar {
+  display: flex;
+  align-items: start;
+
+  .dropdown:not(:first-of-type) {
+    margin-left: 0.5rem;
+  }
+}

--- a/src/assets/js/project_filter.js
+++ b/src/assets/js/project_filter.js
@@ -29,7 +29,35 @@ class ProjectFilter extends HTMLElement {
 
   constructor() {
     super();
+
     this._filters = new Set();
+
+    this._statuses = {
+      label: 'Status',
+      options: {
+        'Ongoing': true, // true indicates the filter should be on by default.
+        'Active': true,
+        'Inactive': false,
+        'Decommissioned': false,
+      }
+    };
+
+    this._topics = {
+      label: 'Topics',
+      options: {
+        'Education': false,
+        'Art': false,
+      }
+    };
+
+    this._technologies = {
+      label: 'Technology',
+      options: {
+        'Ruby': false,
+        'Node.js': false,
+      }
+    };
+
     // Bind the onChange handler to this custom element.
     // If we didn't do this, then onChange would be bound to the checkboxes themselves.
     this.onChange = this.onChange.bind(this);
@@ -52,41 +80,43 @@ class ProjectFilter extends HTMLElement {
     this.removeEventListener('change', this.onChange);
   }
 
-  update() {
-    const template = html`
+  dropdown(filter) {
+    const {label, options} = filter;
+
+    function renderOptions(options) {
+      const out = [];
+      for (const [key, value] of Object.entries(options)) {
+        out.push(html`
+          <div class="form-check">
+            <input type="checkbox" ?checked=${value} class="form-check-input" id="option-${key}" data-tag="${key.toLowerCase()}">
+            <label class="form-check-label" for="option-${key}">
+              ${key}
+            </label>
+          </div>
+        `);
+      }
+      return out;
+    }
+
+    return html`
       <div class="dropdown">
         <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Status
+          ${label}
         </button>
         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
           <div class="px-3 py-1">
-            <div class="form-check">
-              <input type="checkbox" checked class="form-check-input" id="dropdownCheck" data-tag="ongoing">
-              <label class="form-check-label" for="dropdownCheck">
-                Ongoing
-              </label>
-            </div>
-            <div class="form-check">
-              <input type="checkbox" checked class="form-check-input" id="dropdownCheck" data-tag="active">
-              <label class="form-check-label" for="dropdownCheck">
-                Active
-              </label>
-            </div>
-            <div class="form-check">
-              <input type="checkbox" class="form-check-input" id="dropdownCheck" data-tag="inactive">
-              <label class="form-check-label" for="dropdownCheck">
-                Inactive
-              </label>
-            </div>
-            <div class="form-check">
-              <input type="checkbox" class="form-check-input" id="dropdownCheck" data-tag="decommissioned">
-              <label class="form-check-label" for="dropdownCheck">
-                Decommissioned
-              </label>
-            </div>
+            ${renderOptions(options)}
           </div>
         </div>
       </div>
+    `;
+  }
+
+  update() {
+    const template = html`
+      ${this.dropdown(this._statuses)}
+      ${this.dropdown(this._topics)}
+      ${this.dropdown(this._technologies)}
     `;
 
     render(template, this.querySelector('.project-filter__toolbar'));

--- a/src/assets/js/project_filter.js
+++ b/src/assets/js/project_filter.js
@@ -3,10 +3,11 @@ import {html, render} from 'https://unpkg.com/lit-html@^1?module';
 /**
  * @fileoverview
  * 
- * A custom element which wraps the project section of the /projects page.
- * The /projects page contains dropdown buttons with checkboxes to enable or disable tag filters.
- * This element listens for when the user clicks on any of those checkboxes. It then looks
- * at each project and checks to see if the project's card matches any of the enabled filters.
+ * A custom element that wraps the project section of the /projects page. The
+ * /projects page contains dropdown buttons with checkboxes to enable or disable
+ * tag filters. This element listens for when the user clicks on any of those
+ * checkboxes. It then looks at each project and checks to see if the project's
+ * data-tags="" attribute matches any of the enabled filters.
  */
 class ProjectFilter extends HTMLElement {
 
@@ -42,24 +43,8 @@ class ProjectFilter extends HTMLElement {
       }
     };
 
-    this._topics = {
-      label: 'Topics',
-      options: {
-        'Education': false,
-        'Art': false,
-      }
-    };
-
-    this._technologies = {
-      label: 'Technology',
-      options: {
-        'Ruby': false,
-        'Node.js': false,
-      }
-    };
-
-    // Bind the onChange handler to this custom element.
-    // If we didn't do this, then onChange would be bound to the checkboxes themselves.
+    // Bind the onChange handler to this custom element. If we didn't do this,
+    // then onChange would be bound to the checkboxes themselves.
     this.onChange = this.onChange.bind(this);
   }
 
@@ -115,8 +100,6 @@ class ProjectFilter extends HTMLElement {
   update() {
     const template = html`
       ${this.dropdown(this._statuses)}
-      ${this.dropdown(this._topics)}
-      ${this.dropdown(this._technologies)}
     `;
 
     render(template, this.querySelector('.project-filter__toolbar'));
@@ -140,9 +123,9 @@ class ProjectFilter extends HTMLElement {
     // Find every project card
     const projects = Array.from(this.querySelectorAll('.card.projects'));
 
-    // For each project card, grab its data-tags attribute and convert it into an array of tags.
-    // The data-tags attribute should be a comma separated string.
-    // example: data-tags="active,node.js,education"
+    // For each project card, grab its data-tags attribute and convert it into
+    // an array of tags. The data-tags attribute should be a comma separated
+    // string. example: data-tags="active,node.js,education"
     //
     // Check to see if ANY of the project's tags have been enabled in this.filters.
     // If a project does not match any of the filters, then mark it as hidden.

--- a/src/assets/js/project_filter.js
+++ b/src/assets/js/project_filter.js
@@ -1,0 +1,132 @@
+import {html, render} from 'https://unpkg.com/lit-html@^1?module';
+
+/**
+ * @fileoverview
+ * 
+ * A custom element which wraps the project section of the /projects page.
+ * The /projects page contains dropdown buttons with checkboxes to enable or disable tag filters.
+ * This element listens for when the user clicks on any of those checkboxes. It then looks
+ * at each project and checks to see if the project's card matches any of the enabled filters.
+ */
+class ProjectFilter extends HTMLElement {
+
+  /**
+   * Converts an array of tag strings into an internal Set which is used
+   * to filter projects.
+   * @param {string[]} values An array of tag strings
+   */
+  set filters(values) {
+    this._filters = new Set(values);
+    this.filterProjects();
+  }
+
+  /**
+   * @return {Set}
+   */
+  get filters() {
+    return this._filters;
+  }
+
+  constructor() {
+    super();
+    this._filters = new Set();
+    // Bind the onChange handler to this custom element.
+    // If we didn't do this, then onChange would be bound to the checkboxes themselves.
+    this.onChange = this.onChange.bind(this);
+  }
+
+  /**
+   * Runs when the custom element's script loads.
+   */
+  connectedCallback() {
+    this.update();
+    // Do an intial check for any enabled filters.
+    this.onChange();
+    this.addEventListener('change', this.onChange);
+  }
+
+  /**
+   * Runs whenever the custom element is removed from the page.
+   */
+  disconnectedCallback() {
+    this.removeEventListener('change', this.onChange);
+  }
+
+  update() {
+    const template = html`
+      <div class="dropdown">
+        <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Status
+        </button>
+        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+          <div class="px-3 py-1">
+            <div class="form-check">
+              <input type="checkbox" checked class="form-check-input" id="dropdownCheck" data-tag="ongoing">
+              <label class="form-check-label" for="dropdownCheck">
+                Ongoing
+              </label>
+            </div>
+            <div class="form-check">
+              <input type="checkbox" checked class="form-check-input" id="dropdownCheck" data-tag="active">
+              <label class="form-check-label" for="dropdownCheck">
+                Active
+              </label>
+            </div>
+            <div class="form-check">
+              <input type="checkbox" class="form-check-input" id="dropdownCheck" data-tag="inactive">
+              <label class="form-check-label" for="dropdownCheck">
+                Inactive
+              </label>
+            </div>
+            <div class="form-check">
+              <input type="checkbox" class="form-check-input" id="dropdownCheck" data-tag="decommissioned">
+              <label class="form-check-label" for="dropdownCheck">
+                Decommissioned
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    render(template, this.querySelector('.project-filter__toolbar'));
+  }
+
+  /**
+   * Runs whenever a user checks a filter checkbox.
+   * Grabs the data-tag attribute off of the checkbox and compiles them
+   * into an array of tags to filter by.
+   */
+  onChange() {
+    this.filters = Array.from(this.querySelectorAll('.form-check-input'))
+      .filter((item) => item.checked)
+      .map((item) => item.getAttribute('data-tag'));
+  }
+
+  /**
+   * Filter the project cards by their tags.
+   */
+  filterProjects() {
+    // Find every project card
+    const projects = Array.from(this.querySelectorAll('.card.projects'));
+
+    // For each project card, grab its data-tags attribute and convert it into an array of tags.
+    // The data-tags attribute should be a comma separated string.
+    // example: data-tags="active,node.js,education"
+    //
+    // Check to see if ANY of the project's tags have been enabled in this.filters.
+    // If a project does not match any of the filters, then mark it as hidden.
+    projects.forEach((project) => {
+      const projectTags = project.dataset.tags.split(',');
+      for (const tag of projectTags) {
+        if (this.filters.has(tag)) {
+          project.removeAttribute('hidden');
+          return;
+        }
+      }
+      project.setAttribute('hidden', '');
+    });
+  }
+}
+
+customElements.define('project-filter', ProjectFilter);

--- a/src/projects.md
+++ b/src/projects.md
@@ -81,6 +81,14 @@ Projects must demonstrate alignment to OpenOakland’s mission and values. Some 
 - Forming a project team which has lived experience with the issue the project is focused on
 - Conducting user research to understand the needs of the community the project serves
 
+### Inactive projects
+
+Projects with the <span class="badge badge-{{ page.badges['inactive'] }}">Inactive</span> label have either served their purpose or are otherwise no longer actively supported. If you'd like to resume or adapt one of these, submit a [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) at an upcoming Hack Night or in Slack's #leadership channel.
+
+### Decommissioned projects
+
+Projoects with the <span class="badge badge-{{ page.badges['decommissioned'] }}">Decommissioned</span> label are projects that the Steering Committee has formally reviewed and deemed no longer a good fit for OpenOakland based on our 2020 project evaluation pilot. These projects may not be reinstated without submitting a new [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) that substantively addresses the original reasons for discontinuation. Project briefs that are declined by the Steering Committee twice may not be resubmitted without substantive changes.
+
 ---
 
 ## Providing feedback

--- a/src/projects.md
+++ b/src/projects.md
@@ -3,44 +3,48 @@ title: Our Projects
 date:  2020-11-19T07:50:52+00:00
 author: Jess Sand
 layout: page
+scripts: ["/assets/js/project_filter.js"]
 ---
 
-
-[Active projects](#ongoing-projects-that-support-openoaklands-operation)  
+[Projects](#projects)  
 [Becoming an OpenOakland project](#becoming-an-openoakland-project)  
 [Providing feedback](#providing-feedback)  
 
-**Archives**  
-[Past projects](#past-projects)  
-[Decommissioned projects](#decommissioned-projects)  
-
 ---
 
-## Ongoing projects that support OpenOakland's operation
-
-These projects are a great way to get your feet wet as you get to know OpenOakland.
-
-{% for project in site.data.openoakland_projects %}
-{% include project.html %}
-{% endfor %}   
-
-{::comment}
-This comment element is here to "trick" Jekyll's markdown parser, called kramdown, into closing the above list without inserting any content between the list and the next element
-{:/comment}
-
----
-
-## Active projects
+## Projects
 
 The following are official OpenOakland projects that are being actively supported by an existing team. If you see something that interests you, there are a couple of ways you can get involved:
 
 - Join us for our Tuesday [Hack Nights](https://www.meetup.com/OpenOakland/events/) to connect with the project team.
 - Join our [Slack workspace](http://slack.openoakland.org/) and introduce yourself in the project's channel listed in the description.
 
+<project-filter>
+  <div class="project-filter__toolbar"></div>
+  <!-- Ongoing -->
+  {% for project in site.data.openoakland_projects %}
+  {% assign tags = 'ongoing' %}
+  {% include project.html %}
+  {% endfor %}
 
-{% for project in site.data.active_projects %}
-{% include project.html %}
-{% endfor %}
+  <!-- Active -->
+  {% for project in site.data.active_projects %}
+  {% assign tags = 'active' %}
+  {% include project.html %}
+  {% endfor %}
+
+  <!-- Inactive -->
+  {% for project in site.data.inactive_projects %}
+  {% assign tags = 'inactive' %}
+  {% include project.html %}
+  {% endfor %}
+
+  <!-- Decommissioned -->
+  {% for project in site.data.decommissioned_projects %}
+  {% assign tags = 'decommissioned' %}
+  {% include project.html %}
+  {% endfor %}
+</project-filter>
 
 ---
 
@@ -84,24 +88,3 @@ In the spirit of continuous improvement and self-reflection, we welcome any and 
 - Email our [Steering Committee](mailto:steering@openoakland.org) with your input.
 
 You may also email concerns or comments to <safespace@openoakland.org>, which is staffed by two OpenOakland [ombudspeople](https://docs.google.com/document/d/1QR-fr1WnmXkZoVNmWnZ9drzfmaZoPkodEOx-PkExt94/edit#heading=h.3t0te9n2wr7m).
-
----
-
-## Past projects
-
-These projects have either served their purpose or are otherwise no longer actively supported. If you'd like to resume or adapt one of these, check out [Becoming an OpenOakland Project](#becoming-an-openoakland-project) and submit a [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) at an upcoming Hack Night or in Slack's #leadership channel.
-
-{% for project in site.data.inactive_projects %}
-{% include project.html %}
-{% endfor %}
-
----
-
-## Decommissioned projects
-
-Decommissioned projects are projects that the Steering Committee has formally reviewed and deemed no longer a good fit for OpenOakland based on our 2020 project evaluation pilot. These projects may not be reinstated without submitting a new [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) that substantively addresses the original reasons for discontinuation. Project briefs that are declined by the Steering Committee twice may not be resubmitted without substantive changes.
-
-
-{% for project in site.data.decommissioned_projects %}
-{% include project.html %}
-{% endfor %}

--- a/src/projects.md
+++ b/src/projects.md
@@ -4,6 +4,11 @@ date:  2020-11-19T07:50:52+00:00
 author: Jess Sand
 layout: page
 scripts: ["/assets/js/project_filter.js"]
+badges:
+  ongoing: 'primary'
+  active: 'success'
+  inactive: 'secondary'
+  decommissioned: 'dark'
 ---
 
 [Projects](#projects)  
@@ -23,25 +28,25 @@ The following are official OpenOakland projects that are being actively supporte
   <div class="project-filter__toolbar"></div>
   <!-- Ongoing -->
   {% for project in site.data.openoakland_projects %}
-  {% assign tags = 'ongoing' %}
+  {% assign status = 'ongoing' %}
   {% include project.html %}
   {% endfor %}
 
   <!-- Active -->
   {% for project in site.data.active_projects %}
-  {% assign tags = 'active' %}
+  {% assign status = 'active' %}
   {% include project.html %}
   {% endfor %}
 
   <!-- Inactive -->
   {% for project in site.data.inactive_projects %}
-  {% assign tags = 'inactive' %}
+  {% assign status = 'inactive' %}
   {% include project.html %}
   {% endfor %}
 
   <!-- Decommissioned -->
   {% for project in site.data.decommissioned_projects %}
-  {% assign tags = 'decommissioned' %}
+  {% assign status = 'decommissioned' %}
   {% include project.html %}
   {% endfor %}
 </project-filter>


### PR DESCRIPTION
**Note**: This is still a work in progress and not ready to merge, but folks can play around with it and comment on the code.

closes #126

##### _Please describe the changes this PR makes_

- Adds a little snippet so pages can conditionally include scripts. This way the project filter is only loaded on the /projects page.
- Adds a `data-tags=""` attribute to every project card element. This should be a comma separated list of tags.
- Adds a [custom element](https://developers.google.com/web/fundamentals/web-components/customelements) named `<project-filter>` which wraps the project cards and renders a dropdown for filtering the cards by tags. This element could render more than one dropdown if we wanted to include additional categories (stack, topics, etc). Right now it only has one dropdown which filters projects by their status (ongoing, active, inactive, decommissioned).

👉 I ended up removing a lot of the copy on the existing /project page as I was prototyping. Definitely open to ideas for where this content should go 🤔

##### _If your PR changes the appearance of the site, please include desktop and mobile screenshots below_
### Mobile screenshots
![image](https://user-images.githubusercontent.com/1066253/104277893-90eb5b80-545c-11eb-825a-902306d7c60d.png)

<br>

### Desktop screenshots
![image](https://user-images.githubusercontent.com/1066253/104277924-9f397780-545c-11eb-8bab-ad0cc03af772.png)
