### PR TITLE
Replace mentions of #leadership with #oo-leadership

### DIFF
--- a/src/about-us.md
+++ b/src/about-us.md
@@ -44,7 +44,7 @@ Formal decision-making is done by the Steering Committee, which meets monthly. E
 
 ![Organization chart depicting the Steering Committee, consisting of elected Treasurer/Recorder, Hack Night Lead, Communications Lead, and Community Organizer, plus one project representative per project. Appointed roles include two ombuds people and one steering committee chairperson.](/assets/images/OpenOakland-leadership-structure.png)
 
-To contact the steering committee, email [steering@openoakland.org](mailto:steering@openoakland.org) or join the #leadership channel in [Slack](http://slack.openoakland.org/).
+To contact the steering committee, email [steering@openoakland.org](mailto:steering@openoakland.org) or join the #oo-leadership channel in [Slack](http://slack.openoakland.org/).
 
 ## How you can get involved
 

--- a/src/calendar.md
+++ b/src/calendar.md
@@ -18,7 +18,7 @@ The following events happen during Tuesday's Hack Night on the following dates:
 - **First Tuesday of each month**  
 Demo night: See the latest updates from active projects.  
 - **Third Tuesday of each month**  
-Steering committee meeting: Decision-making body for OpenOakland (open to membership; agenda is posted 1 week prior in #leadership on Slack).  
+Steering committee meeting: Decision-making body for OpenOakland (open to membership; agenda is posted 1 week prior in #oo-leadership on Slack).  
 - **Last Tuesday of each month**  
 New member orientation: Get a personal introduction to OpenOakland.
 

--- a/src/projects.md
+++ b/src/projects.md
@@ -52,7 +52,7 @@ If you have a new idea for an OpenOakland project:
 
 1. **Fill out the [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing)**. We encourage you to join our [Slack workspace](http://slack.openoakland.org/) and share your draft with our membership, so we can collaborate together as you develop your idea.
 
-2. **Submit your draft brief to the #leadership channel** on Slack for formal consideration. Provided your brief is submitted at least two weeks in advance, it will be reviewed at the next Steering Committee meeting (a group of elected leadership and existing project reps), and you'll get some initial feedback and be asked to make adjustments accordingly.
+2. **Submit your draft brief to the #oo-leadership channel** on Slack for formal consideration. Provided your brief is submitted at least two weeks in advance, it will be reviewed at the next Steering Committee meeting (a group of elected leadership and existing project reps), and you'll get some initial feedback and be asked to make adjustments accordingly.
 
 3. **Make any requested adjustments** based on the Steering Committee's feedback and resubmit the final brief.
 
@@ -89,7 +89,7 @@ You may also email concerns or comments to <safespace@openoakland.org>, which is
 
 ## Past projects
 
-These projects have either served their purpose or are otherwise no longer actively supported. If you'd like to resume or adapt one of these, check out [Becoming an OpenOakland Project](#becoming-an-openoakland-project) and submit a [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) at an upcoming Hack Night or in Slack's #leadership channel.
+These projects have either served their purpose or are otherwise no longer actively supported. If you'd like to resume or adapt one of these, check out [Becoming an OpenOakland Project](#becoming-an-openoakland-project) and submit a [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) at an upcoming Hack Night or in Slack's #oo-leadership channel.
 
 {% for project in site.data.inactive_projects %}
 {% include project.html %}


### PR DESCRIPTION
closes #125 

Small change to replace `#leadership` with `#oo-leadership`.

I also did a quick find/replace for "leadership channel" but didn't find anything else so I think/hope this should cover it :)
