### PR TITLE
fix small typos and styles

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -30,7 +30,7 @@ h1, h2, h3, h4, h5 {
   font-family: 'Open Sans', Helvetica, sans-serif;
 }
 
-h1, h4, h5 {
+h1, h4, h5, .h5 {
   color: #013743;
   margin-top:1.9rem;
 }
@@ -64,7 +64,7 @@ h4 {
   font-weight: bold;
 }
 
-h5 {
+h5, .h5 {
   font-style: italic;
   font-size: 1.1rem;
   line-height: 1.4;

--- a/src/index.md
+++ b/src/index.md
@@ -5,9 +5,9 @@ title: We are OpenOakland
 
 <section class="row page-section">
   <div class="col-sm-8">
-    <h5>OpenOakland bridges <b>technology</b> and <b>community</b> for a thriving and equitable Oakland.</h5>
+    <p class="h5 mt-1">OpenOakland bridges <b>technology</b> and <b>community</b> for a thriving and equitable Oakland.</p>
 
-    <p>As part of the <a href="https://brigade.codeforamerica.org" target="_blank">Code for America Brigade network</a>, we are a welcoming and inclusive volunteer group of developers, designers, data geeks, and citizen activists who use creative technology to solve civic and social problems.</p>
+    <p>As part of the <a href="https://brigade.codeforamerica.org" target="_blank">Code for America brigade network</a>, we are a welcoming and inclusive volunteer group of developers, designers, data geeks, and citizen activists who use creative technology to solve civic and social problems.</p>
   </div>
 
   <div class="col-sm-4">
@@ -53,7 +53,7 @@ title: We are OpenOakland
   </p>
 
   <p>
-  We hope you'll join us! If you can't make this event, <a href="https://www.meetup.com/OpenOakland{{ event.group.urlname}}" target="_blank">check our Meetup group for our future events</a>. You'll find us every Tuesday night on Zoom at .
+  We hope you'll join us! If you can't make this event, <a href="https://www.meetup.com/OpenOakland" target="_blank">check our Meetup group for our future events</a>. You'll find us every Tuesday night on Zoom at <a href="http://oakca.us/hack-night" target="_blank">http://oakca.us/hack-night</a>.
   </p>
 
 </section>


### PR DESCRIPTION
closes #118

- Fixes a few small typos
- Adds a `.h5` style which is essentially the same as the `h5` style that can be used on any element that needs to emulate the look of an `h5`. I think Bootstrap already ships `.h1` - `.h6` styles but I don't think the site's css has been overriding them (it's only overriding h1-h6 styles).
- Reduced the top margin a tad on the h5

##### _If your PR changes the appearance of the site, please include desktop and mobile screenshots below_
### Desktop screenshots

**Before**:
![image](https://user-images.githubusercontent.com/1066253/105123926-e394cb00-5a8d-11eb-8d43-1758a40c8c74.png)

**After**:
![image](https://user-images.githubusercontent.com/1066253/105123912-d7107280-5a8d-11eb-9073-80a54b0bd0b1.png)
