### PR TITLE
Minor content updates

### DIFF
--- a/src/_includes/next-meeting.html
+++ b/src/_includes/next-meeting.html
@@ -1,4 +1,4 @@
-<h2>Our Next Meeting</h2>
+<h2>Our next meeting</h2>
 {% assign next_event = site.data.events[0] %}
 <div class="card home__event-card">
   <div class="row no-gutters">

--- a/src/_includes/steering-faq.html
+++ b/src/_includes/steering-faq.html
@@ -45,6 +45,7 @@
           <p>Agenda items should be relevant to brigade-wide operations. This may include new project submissions or ideas, proposals for policy or process changes, general discussion items about how we work together or specific activities, and questions, concerns, or feedback for the group. Projects who need brigade support can also add discussion items to the agenda.</p>
           <h4>How do I add to the agenda?</h4>
           <p>The agenda is pinned to the <a href="https://app.slack.com/client/T02FEGG84/C02FG2BUX">#oo-steering-committee channel</a> in Slack. You may add your item to the appropriate section of the agenda according to the instructions in the doc. If you don't automatically have edit permissions, contact the Steering Committee Chair.</p>
+          <p>We recommend adding your items as far in advance as possible, to give members the chance to get familiar with your item. The Steering Committee chair will make a reasonable effort to ensure all items are heard but may limit the agenda or time spent on individual items at their discretion.</p>
         </div>
       </div>
 

--- a/src/index.md
+++ b/src/index.md
@@ -34,15 +34,17 @@ title: We are OpenOakland
 </section>
 
 <section class="row page-section">
-  <div class="col-12">
+  <div class="col-2">
+    <img class="img-fluid" alt="Slack logo" src="/assets/images/OO-on-Slack-300x128.png" width="100" style="margin-top:50px;" />
+  </div>
+
+  <div class="col-10">
     <h2>Join us in Slack</h2>
   </div>
 
-  <div class="col-8">
-    <p>OpenOakland members primarily use Slack for all communication. You can join our Slack <a href="http://slack.openoakland.org/">here</a>.</p>
+  <div class="col-12">
+    <p>OpenOakland members primarily use Slack for connecting and communicating. By joining our Slack space, you agree to our <a href="/code-of-conduct">Code of Conduct</a> (upshot: be cool to each other; don't spam).</p>
+    <p><a href="https://join.slack.com/t/openoakland/shared_invite/zt-n4d7tx2t-UVIN7a769e4oc9j7PgM3HA">Join us in Slack</a>.</p>
   </div>
 
-  <div class="col-4">
-    <img class="img-fluid" alt="RSVP on Meetup" src="/assets/images/OO-on-Slack-300x128.png" width="100" />
-  </div>
 </section>


### PR DESCRIPTION
## Description
Closes #159 and #158 

- Fix Slack link
- Add CoC link to Slack paragraph
- Adjust casing on Next Meeting header
- Add FAQ clarification on timing under "How do I add to the agenda"
