### PR TITLE
Js update hack night signposting

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -41,4 +41,5 @@
    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap" rel="stylesheet">
   {% if site.google_analytics and jekyll.environment == 'production' %}
   {% include google-analytics.html %} {% endif %}
+  <script src="https://kit.fontawesome.com/510ea83d73.js" crossorigin="anonymous"></script>
 </head>

--- a/src/_includes/zoom-link.html
+++ b/src/_includes/zoom-link.html
@@ -1,0 +1,3 @@
+<div class="alert alert-info" role="alert">
+Looking for the Zoom link? Find it the #oo-general channel in Slack. <span class="text-small brand-link">(<a href="https://docs.google.com/document/d/1VWZQ_3ehP5j0IOTY0nJClvQPll3ivSkuAdh5YsOhO_U/edit?usp=sharing" target="blank" class="text-small brand-link">Access Slack <i class="fas fa-external-link-square-alt"></i></a>)</span>
+</div>

--- a/src/calendar.md
+++ b/src/calendar.md
@@ -8,6 +8,8 @@ layout: page
 {% include next-meeting.html %}
 
 ## Join us every Tuesday on Zoom
+{% include zoom-link.html %}
+
 **6:00-6:30** Intro for newcomers  
 **6:30-8:30** Brigade-wide activities for everyone
 

--- a/src/index.md
+++ b/src/index.md
@@ -18,7 +18,6 @@ title: We are OpenOakland
   </div>
 </section>
 
-{% include announcement-home.html %}
 
 <section class="page-section">
   {% include next-meeting.html %}
@@ -28,7 +27,7 @@ title: We are OpenOakland
   </p>
 
   <p>
-  We hope you'll join us! If you can't make this event, <a href="https://www.meetup.com/OpenOakland" target="_blank">check our Meetup group for our future events</a>. 
+  We hope you'll join us! If you can't make this event, <a href="https://www.meetup.com/OpenOakland" target="_blank">check our Meetup group for our future events</a>.
   </p>
 
 </section>


### PR DESCRIPTION
Pushes the following changes:

- Adds signpost to Zoom link on /calendar page
- Adds Font Awesome capability to the site
- Removes Insurrection Statement alert from home page

![Screenshot_2021-04-13 Calendar](https://user-images.githubusercontent.com/32755410/114599155-99b02100-9c47-11eb-8dc3-0bb59eaaf7f8.png)
