### PR TITLE
unbold five words to separate header from text

### DIFF
--- a/src/_posts/2022-02-08-2022-leadership.md
+++ b/src/_posts/2022-02-08-2022-leadership.md
@@ -48,7 +48,7 @@ Co-leading a consensus-based group of volunteers is a wild ride! During the pand
 - **Be the change you want to see.** It may sound like a platitude but the truth is that if we want to see tech in Oakland change to serve our community, we have to make it happen.
 - **Learn more about your city and get to know its people.** OpenOakland encourages you to look outward and connect with people you might not cross paths with otherwise.
 - **Practice consensus-based decision-making with a group of curious and creative Oaklanders.** Practicing the day-to-day work of meeting each other's needs at the person-to-person level is incredibly powerful. It’s a chance to explore power-sharing and decision-making, and it will give you a whole new perspective on what you can accomplish in the world.
-- **Build marketable skills that make your work better. We’re not gonna lie:** leadership looks great on a resume. You’ll stretch new muscles while putting your own experiences and expertise to work. OpenOakland co-leads often discover surprising things about what they're able to accomplish.
+- **Build marketable skills that make your work better.** We’re not gonna lie: leadership looks great on a resume. You’ll stretch new muscles while putting your own experiences and expertise to work. OpenOakland co-leads often discover surprising things about what they're able to accomplish.
 
 ## Help us find great community leaders
 


### PR DESCRIPTION
####No issue number created####

This change is a tiny text clean up for a bullet on the page announcing the leadership elections.
It changes:
"**Build marketable skills that make your work better. We’re not gonna lie:** leadership looks great on a resume."
to
"**Build marketable skills that make your work better.** We’re not gonna lie: leadership looks great on a resume."
