### PR TITLE
Add blog post: Dec & Jan SC Recap

### DIFF
--- a/src/_data/active_projects.yml
+++ b/src/_data/active_projects.yml
@@ -21,13 +21,13 @@
 -
   name: Funding Public Safety
   image:
-  website: https://forms.gle/iVDjPfxdmxXeFMf36
-  repo: https://docs.google.com/document/d/1NNJ2tPtBmvMce_V83NFBiRxmPeErWpGAZpCh7iHhWEE/edit?usp=sharing
-  leader: Open
+  website: https://bit.ly/fps-interest
+  repo: https://github.com/openoakland/funding-public-safety/
+  leader: Jess S.
   slack_id: T02FEGG84
   slack_channel: project-active-funding-public-safety
-  description: "The City allocates about $24 million each year to the Dept. of Violence Prevention (Oakland Unite), OPD, and the Oakland Fire Dept. to fund public safety and violence prevention programs. This pool of money is overseen by an oversight commission (the SSOC), a volunteer group of city residents appointed by the City. OpenOakland's Funding Public Safety project is aimed at supporting the SSOC's oversight efforts by making the City's Measure Z evaluation reports more meaningful so the SSOC, impacted communities, and the general public can better understand how the money is being spent and how effective these programs are. We're looking for folks to assess the community impacts of this project, analyze program data, and develop a dataviz strategy."
-  tech: TBD (spreadsheets for now!)
+  description: "Funding Public Safety explores how Oakland spends Measure Z's approximately $24 million annual budget, so Oaklanders can better understand the City's approach to public safety and violence prevention. We're currently looking for data entry folks to pull information from PDFs into spreadsheets, dataviz designers and front-end developers, and especially input and participation of community partners and residents impacted by violence."
+  tech: Eleventy static site generator, Bootstrap CSS framework, spreadsheets and various dataviz tools
 -
   name: Open Budget Oakland
   image: openbudgetoakland_300x233.png

--- a/src/_data/resources-brigadeops.yml
+++ b/src/_data/resources-brigadeops.yml
@@ -35,7 +35,7 @@
  author: Code for America
  description: Letter declaring OpenOakland’s relationship with Code for America for 501(c)(3) status tax exemption. Can be provided to vendors and donors who need proof of our tax-exempt status.
  format: PDF
- link: https://drive.google.com/file/d/1i6BzWwVQHYSPD_Aa9HwqCpc8MEtpcqC2/view?usp=sharing
+ link: https://drive.google.com/file/d/185rNREwLz27oi4e4E3nBiGaV1K4wxksD/view?usp=sharing
  button-text: Download PDF
  secondaryLink:
  secondaryLinkText:
@@ -45,7 +45,7 @@
  author: Code for America, OpenOakland
  description: The agreement that outlines our brigade relationship with Code for America. This document should be updated annually or when brigade leadership changes.
  format: PDF
- link: https://drive.google.com/file/d/1PIbFhohFHl5aiYpsEkDqL6Iul-rv7vN_/view?usp=sharing
+ link: https://drive.google.com/file/d/12sbk7btqWpdqB_OBBDaiYiS2Arx8SJ0w/view?usp=sharing
  button-text: Download PDF
  secondaryLink:
  secondaryLinkText:

--- a/src/_posts/2021-11-3-october-steering-committee-recap.md
+++ b/src/_posts/2021-11-3-october-steering-committee-recap.md
@@ -1,100 +1,70 @@
 ---
-title: "Steering Committee Recap: Oct 2021"
+title: "Steering Committee Recap: Dec-Jan"
 author: OpenOakland
 layout: post
-date: 2021-11-03 00:00:00 -0800
+date: 2022-02-11 00:00:00 -0800
 permalink: updates/:title/
-post-excerpt: "It’s hard to believe that the end of the year is already peaking around the corner and we’re starting to talk about OpenOakland leadership elections! While October’s meeting tackled the logistical realities of running our upcoming election cycle and managing project requirements, we also continued to explore the practice of democratic decision making and how that impacts the work we do..."
+post-excerpt: "We're a little late with recaps thanks to the end-of-year holidaze. Some unfortunate Twitter trolling upped the urgency in resolving some existing project account management challenges but we identified a path forward that appears feasible to all. We made some exciting progress as we continue to commit to collaborative culture building and brigade strategy, so read on for some community training opportunities..."
 ---
 
-**It’s hard to believe that the end of the year is already peaking around the corner and we’re starting to talk about OpenOakland leadership elections!**
+While our monthly Steering Committee meetings are mainly operational in nature, they have historically been one of the few places where the core team can come together for open discussion of brigade strategy and specific issues. This means dense agendas and even denser recaps. We’re finally catching up from the holidaze (!), so here’s a high-level recap of both December and January meetings.
 
 ![Green-tinged photo of OpenOakland members seated around tables in City Hall overlaid with the words 'Steering Committee' in white.](/assets/images/blog/2021-07-Banner-meetup-Steering.png)
 
-This has absolutely been a year of reflection for our brigade, even as we’ve welcomed in new volunteers who are helping to shape our future vision. Steering Committee meetings have become a place where we can have honest conversations about the challenges of wrangling so many different perspectives and experiences. We still have a lot of learning to do together, and it’s exciting to think about the possibilities. While October’s meeting tackled the logistical realities of running our upcoming election cycle and managing project requirements, we also continued to explore the practice of democratic decision making and how that impacts the work we do.
-
-If you’re interested in learning more about OpenOakland [leadership opportunities](/how-we-work/), email [steering@openoakland.org](mailto:steering@openoakland.org) or join us at an [upcoming meetup](https://www.meetup.com/OpenOakland/events/).
-
 ***Jump to:***  
-[Brigade announcements](#brigade-announcements) | [Vote: Election kick-off](#vote-election-kick-off) | [Discussion: Moving the election cycle](#discussion-moving-the-election-cycle) | [Discussion: Democratic participation processes](#discussion-democratic-participation-processes) | [Discussion: Councilmatic project status](#discussion-councilmatic-project-status)
+[CfA MOU signing](#negotiated-and-signed-2022-code-for-america-memorandum-of-understanding) | [Culture change and training opportunities](#discussion-options-for-addressing-culture-change) | [Councilmatic and Open Disclosure updates](#discussion-councilmatic-status-updates) | [2022 planning](#discussion-2022-planning)
 
-## Brigade announcements
+## Negotiated and signed: 2022 Code for America Memorandum of Understanding
 
-- [Brigade Congress recordings](https://cfa.osp.cat/conferences/congress/program/52) are now available. Jess especially recommends [Victory of Greenwood](https://cfa.osp.cat/conferences/congress/f/52/meetings/56) hosted by Code for Tulsa and [Making decisions together: Brigades and beyond](https://cfa.osp.cat/conferences/congress/f/52/meetings/65), hosted by Sierra Ramírez.
-- CfA is launching a [pilot aimed at helping brigades implement democratic governance structures](https://docs.google.com/document/d/1_77vITwlrLkpTC_QNGCy0egBQJ92HtfF7RILUB83ybk/edit?usp=sharing) that are in line with our recent culture conversations. Jess will be introducing a vote to participate in November's Steering Committee meeting.
-- Niels is exploring potential [Figma](https://www.figma.com) licensing with CfA.
-- Ombuds: no new conduct reports received.
-- CfA culture hiring conversation: co-leads [need to follow up](/updates/september-steering-committee-recap/#discussion-seeking-code-for-americas-support-in-our-efforts-to-hire-culture-and-equity-expertise) with Ben to discuss budget proposal for training pilot.
-- 11/23 meetup cancelled (week of Thanksgiving).
+The CfA MOU outlines our relationship with our parent organization. After a full Steering Committee review and discussion, the team voted to approve signing of our memorandum of understanding (MOU) with Code for America, with several key revisions proposed. After some negotiation and discussion with CfA to address issues of data privacy and “what if” scenarios, we signed the new 6-month MOU.  Download the PDF (also available on our Resources page).
 
-## Vote: Election kick-off
-OpenOakland's [Bylaws](https://docs.google.com/document/d/1QR-fr1WnmXkZoVNmWnZ9drzfmaZoPkodEOx-PkExt94/edit#heading=h.ghwdygxfwo03) stipulate that annual leadership elections need to happen November-December. The first official step to kicking off the cycle is appointing two trusted parties to administrate the election process. SC voted unanimously to appoint Jonathan M. and Ronald P. Both accepted the role. SC approved the following timeline for the 2022 term:
+## Discussion: Options for addressing culture change
 
-- **11/2-15:** Nominations open at start of hack night (2 hack nights)
-- **11/16-29:** Trusted parties finalize candidates (over T-day, allowing plenty of time if we don’t get enough nominees)
-- **11/30-12/6:** Campaigning (1 hack night)
-- **12/7-17:** Voting (2 hack nights)
-- **12/21:** 2022 co-leads announced
+This year-long conversation continued to explore a multi-faceted approach that includes:
 
-[See calendar view >](https://docs.google.com/document/d/1r9GkeCHToUcNW1UgRms4N7-G0IIbzsKsbGNlmMZeB3Y/edit?usp=sharing)
+- **Direct skills training in conflict management and facilitation** for the Steering Committee (with the intent of that knowledge being shared across the brigade).
+- **Conflict resolution** to acknowledge and address specific past and/or existing trauma.
+- **Ongoing training and/or culture programming** to ensure a sustained shift over time.
 
-## Discussion: Moving the election cycle
+With these three tracks of work in mind, the Steering Committee discussed the pros and cons of the several related opportunities and challenges:
 
-The approved 2021 timeline is imminent and most present acknowledged concern about how realistic it is. In general, the Nov/Dec elections cycle as outlined in the Bylaws is extremely challenging, making full engagement and participation of candidates, administrators, and voters difficult.
+### Discussion and decision: Direct skills training in conflict management and facilitation
 
-- Ronald raised the question of whether the Nov-Dec timing was even appropriate overall, given its consistent challenges with timing each year.
-- This prompted a discussion about amending the bylaws to move elections to Q1:
-  - To avoid any potential conflict of interest in extending this year’s leadership terms, Jess suggested the 2022 leadership term could be extended by 3 months. This would allow them to oversee elections in Q1 2023.
-  - Several members indicated they didn’t see an extension of this year’s leadership term to be problematic, if it meant addressing the elections challenge sooner.
-  - Current co-leads agreed to discuss their willingness/ability to serve through Q1 2022 and return to the group with a response. If co-leads are willing to serve in order to support a Q1 2022 election, a proposal would be put to SC to that effect.
+We continued discussion about hiring SEEDS Community Resolution Center, one of the few affordable training options that met our criteria of being local, BIPOC-led, and focused on communities like our collective. Even with their flexible pricing, it would use up at least a third of our financial reserves. We remained unresolved in December but by January’s meeting had come up with an alternative solution.
 
-## Discussion: Democratic participation processes
-In addition to the discussion around the impact of a rushed elections cycle on member participation and representation, we explored a couple of other issues around how best to ensure members can engage and participate to the degree they’re comfortable.
+**Thanks to some lucky timing and the generosity of Code for America, we were able to secure space in SEEDS’ public Building Restorative Spaces workshop series for the entire Steering Committee and a limited number of seats for additional brigade members.** We’re so excited to finally be committing to this work as a team and will share more on the blog in the weeks to come. If you’re interested in participating in this training as part of your OpenOakland experience, complete this interest form.
 
-### Moving toward consensus: Fist to Five
-We experimented using the [Fist to Five voting method](https://www.ncfp.org/knowledge/fist-to-five-voting-and-consensus/) when trying to move the group closer to a consensus vote. This process is a relatively quick “gut check” to understand the degrees of dissent or agreement with a given proposal or decision. Someone reads out the proposal (typically a yes/no decision), and everyone holds up (or types out) the number of fingers representing how they feel:
+### Discussion: Conflict resolution and healing options through CfA
 
-![Illustration of six hands of different skin tones, one as a fist and the others each holding up one, two, three, four, and five fingers.](/assets/images/blog/2021-10-Fist-to-Five-1200x300.png)
+Alongside the training effort, Code for America offered us an opportunity to participate in an initiative aimed at “restoration of relationships and healing, post-traumatic events” through listening practice. With few details at this stage, we agreed that we’d keep this as an option to be pursued alongside any formal training, since individuals can opt in if they feel it will be personally meaningful. Jess took on the action items to find out if other brigades are participating and to share more details as they become available.
 
-- **0 fingers (fist):** I want to block this from going forward (opposed to the fundamental principle of the proposal)
-- **1 finger:** I object but defer to the group (would prefer to see major changes)
-- **2 fingers:** I can live with it as-is (would prefer minor changes)
-- **3 fingers:** Okay with me
-- **4 fingers:** I support this
-- **5 fingers:** I’m all in/strongly support this
+### Discussion and decision: Review of our Code of Conduct process
 
-The range of votes tells us how much consensus there is and whether further discussion or an amendment to the proposal is needed. The group does need to explicitly decide its threshold for tabling a formal vote. For really important decisions, for example, we might require further discussion or amendment of the proposal if anyone throws two fingers or below. For incidentental decisions, we might choose to move forward only if no fists are thrown, replacing a formal vote entirely.
+The enforcement of conduct issues has been one of our enduring challenges over the years and we’re overdue for a dedicated initiative to revise this process. Our CoC is identical to CfA’s but we’ve also had a pair of Ombudspeople who have been historically tasked with fielding conduct reports, with mixed effects. The current Ombuds team has repeatedly pushed the Steering Committee to reconsider the role.
 
-We found that the process was surprisingly successful at keeping the conversation moving forward and identifying where people’s sticking points were. While there’s certainly potential for overuse, in general it would be good to see this adopted more widely across the brigade. It’s important that the proposal be stated clearly prior to voting and that voters are able to see the definitions while voting. We accomplished this by having the chair read the proposal and definitions, while another co-lead pasted the voting definitions into the Zoom chat. Sharing a visual slide of the definitions is recommended, too.
+- **In December’s meeting, the Steering Committee voted unanimously to participate in an initial consultation with a third-party team that Code for America is considering to review their CoC process.** CfA invited OpenOakland into that engagement as a stakeholder and example of how the CoC plays out at the brigade level. That consultation was scheduled for after January’s meeting. More to come!
+- **The Steering Committee also voted in December to leave the Ombuds role vacant until the CoC process has been reviewed** (votes: AK—aye, ER—aye, FB—aye, JB—aye, NT—aye, JS—aye, TT—nay). With the outgoing Ombuds having served multiple terms, no reports coming through that channel all year, and a process review pending, we opted to direct all CoC reports to Steering Committee and provide CfA’s safespace@codeforamerica.org email as a fallback for those who don’t feel comfortable going through Steering Committee. We’re grateful for Ronald and Mary’s dedication over the years and are excited for them to be able to participate in the brigade in a renewed capacity.
 
-We were first introduced to this method through Bonnie Wolfe of [Hack for LA](https://www.hackforla.org/), another example of powerful learnings we can glean from the wider brigade network.
+## Discussion: Councilmatic status updates
 
-### Ensuring new voting reps feel equipped to participate
-Two members abstained from voting on the upcoming election schedule. These two members also happened to be first-time Steering Committee voters (each project team is expected to send a voting rep to the Steering Committee, and these particular members had been nominated by their teams for the first time). When asked about the reasoning for their abstention (rather than a No vote), they indicated a lack of certainty around brigade processes and feeling a little “too new” to feel comfortable making big election-related decisions. This begs the question: how do we onboard new voting members so they feel equipped, informed, and empowered to serve in the role?
+The brigade continues to discuss how best to support the health of the Councilmatic project.
 
-Given that people’s attendance at our meetups is unpredictable, our hope—and need—is that people feel they can hit the ground running and participate to their full ability and desire without a lot of onboarding. But clearly, folks sometimes feel thrown into the deep end. Some approaches that might help improve the voting experience:
+- Councilmatic’s Project Lead reports that the GitHub repo is actively being updated and that the credentials for the Councilmatic Twitter account are inaccessible to the current team. The account has tweeted personal attacks against OpenOakland’s leadership team on multiple occasions. The Steering Committee once again expressed the urgency of either transferring account ownership to OpenOakland or disconnecting the account from the project altogether, seeking assistance from the project’s current Project Lead.
+  - The current Project Lead introduced a 3-month plan to transition the project to a new Twitter account. As of this writing, the Steering Committee still has not been given credentials to the new account. Several members expressed concern at the slow timeline and lack of cooperation.
+  - The Steering Committee approved a formal request that the Councilmatic team remove all links to the current troll account as soon as possible (votes: AK—aye, ER—aye, FB—aye, JB—aye, NT—aye, JS—aye, TT—nay). As of this writing, this has been completed.
+  - The Steering Committee also unanimously approved language for a public Twitter response from OpenOakland’s Twitter account and to have the Comms Lead file an imposter account complaint. As of this writing, both have been completed.
 
-- **Clearly define the role and expectations** and post them somewhere accessible.
-- **Provide the Steering Committee agenda a full week prior to the meeting;** this doesn’t always happen but striving for enough lead time is key for members to feel prepared.
-- **Recap the voting guidelines and share a visual slide that recaps them at the top of every meeting.** This formality often gets overlooked in the interest of speed, but that can make it very confusing for newcomers. Even for regulars, it’s helpful to repeat the expectations to ensure continued alignment.
+## Discussion: Open Disclosure bug report
 
+In response to a public tweet calling OD data into question, the Steering Committee reviewed the issue and confirmed this was due to a technical bug that was fixed when it was initially reported last year. The Open Disclosure team agreed to respond via Twitter with a reminder about the bug and invitation to attend our meetings. As of this writing, this has been completed.
 
-## Discussion: Councilmatic project status
-Following last month’s discussion of [project requirements](https://openoakland.org/updates/september-steering-committee-recap/#discussion-project-requirements), co-leads reached out to Councilmatic’s project lead to request that the team focus on meeting project requirements by the October Steering Committee meeting. Those requirements included:
+## Discussion: 2022 planning
 
-- Ensuring the current live production build is hosted in OpenOakland’s repo.
-- Updating the repos’ ReadMe files to include basic instructions for how to contribute to the project and how to contact the brigade or project team.
-- Providing the Steering Committee with a link to up-to-date project documentation.
-- Providing the Steering Committee with account credentials for any platforms or accounts used to manage the project, including the Councilmatic Twitter account.
+Additional discussions in December and January focused on the year ahead:
 
-Unfortunately, these requirements weren’t met as of October’s meeting and Councilmatic’s project lead was not present due to illness. Co-leads expressed concern that the team was not making a good faith effort to keep the project open and accessible and under the control of the full brigade, and discussion ensued about how best to handle the situation.
-
-The Steering Committee discussed some potential approaches such as:
-
-- Extending the timeline to give the Councilmatic team more time to meet these requirements.
-- Moving the project into [Idle status](https://openoakland.org/projects/#status-definitions) and removing the current team as repo contributors. This doesn’t solve the issue that the Steering Committee still doesn’t have full access to the current project, though.
-- Escalate to Code for America, given that a brigade project is currently not being shared with the brigade itself. Co-leads felt this might be premature and agreed to huddle and follow up with the Steering Committee on next steps between now and the Nov. 16 SC meeting.
+- **2022 is our 10-year anniversary!** There is general enthusiasm for acknowledging/celebrating in some way but also concern for the team’s capacity to do so.
+- **Strategy and vision:** How do we sustain the work we’ve been doing?  Or how do we shift the work to something more sustainable? There continues to be concern about how to resource everything we want and need to do.
 
 ---
 
-_Steering Committee meets the Third Tuesday of each month and is open to all OpenOakland members. [Read more about how Steering Committee works](/how-we-work) and how to participate. Our next meeting is [November 16](https://www.meetup.com/OpenOakland/events/281161293)._
+_Steering Committee meets the Third Tuesday of each month and is open to all OpenOakland members. [Read more about how Steering Committee works](/how-we-work) and how to participate. Our next meeting is [Tues., February 15](https://www.meetup.com/OpenOakland/events/hmftrsydcdbtb/)._

--- a/src/_posts/2021-11-3-october-steering-committee-recap.md
+++ b/src/_posts/2021-11-3-october-steering-committee-recap.md
@@ -16,7 +16,7 @@ While our monthly Steering Committee meetings are mainly operational in nature, 
 
 ## Negotiated and signed: 2022 Code for America Memorandum of Understanding
 
-The CfA MOU outlines our relationship with our parent organization. After a full Steering Committee review and discussion, the team voted to approve signing of our memorandum of understanding (MOU) with Code for America, with several key revisions proposed. After some negotiation and discussion with CfA to address issues of data privacy and “what if” scenarios, we signed the new 6-month MOU.  Download the PDF (also available on our Resources page).
+The CfA MOU outlines our relationship with our parent organization. After a full Steering Committee review and discussion, the team voted to approve signing of our memorandum of understanding (MOU) with Code for America, with several key revisions proposed. After some negotiation and discussion with CfA to address issues of data privacy and “what if” scenarios, we signed the new 6-month MOU.  [View the PDF](https://drive.google.com/file/d/12sbk7btqWpdqB_OBBDaiYiS2Arx8SJ0w/view?usp=sharing) (also available on our [Resources](resources/#brigade-operations) page).
 
 ## Discussion: Options for addressing culture change
 
@@ -30,9 +30,9 @@ With these three tracks of work in mind, the Steering Committee discussed the pr
 
 ### Discussion and decision: Direct skills training in conflict management and facilitation
 
-We continued discussion about hiring SEEDS Community Resolution Center, one of the few affordable training options that met our criteria of being local, BIPOC-led, and focused on communities like our collective. Even with their flexible pricing, it would use up at least a third of our financial reserves. We remained unresolved in December but by January’s meeting had come up with an alternative solution.
+We continued discussion about hiring [SEEDS Community Resolution Center](https://www.seedscrc.org/), one of the few affordable training options that met our criteria of being local, BIPOC-led, and focused on communities like our collective. Even with their flexible pricing, it would use up at least a third of our financial reserves. We remained unresolved in December but by January’s meeting had come up with an alternative solution.
 
-**Thanks to some lucky timing and the generosity of Code for America, we were able to secure space in SEEDS’ public Building Restorative Spaces workshop series for the entire Steering Committee and a limited number of seats for additional brigade members.** We’re so excited to finally be committing to this work as a team and will share more on the blog in the weeks to come. If you’re interested in participating in this training as part of your OpenOakland experience, complete this interest form.
+**Thanks to some lucky timing and the generosity of Code for America, we were able to secure space in SEEDS’ public [Building Restorative Spaces workshop series](https://www.seedscrc.org/building-restorative-spaces) for the entire Steering Committee and a limited number of seats for additional brigade members.** We’re so excited to finally be committing to this work as a team and will share more on the blog in the weeks to come. If you’re interested in participating in this training as part of your OpenOakland experience, [complete our interest form](http://oakca.us/seeds1).
 
 ### Discussion: Conflict resolution and healing options through CfA
 

--- a/src/_posts/2021-11-3-october-steering-committee-recap.md
+++ b/src/_posts/2021-11-3-october-steering-committee-recap.md
@@ -16,7 +16,7 @@ While our monthly Steering Committee meetings are mainly operational in nature, 
 
 ## Negotiated and signed: 2022 Code for America Memorandum of Understanding
 
-The CfA MOU outlines our relationship with our parent organization. After a full Steering Committee review and discussion, the team voted to approve signing of our memorandum of understanding (MOU) with Code for America, with several key revisions proposed. After some negotiation and discussion with CfA to address issues of data privacy and “what if” scenarios, we signed the new 6-month MOU.  [View the PDF](https://drive.google.com/file/d/12sbk7btqWpdqB_OBBDaiYiS2Arx8SJ0w/view?usp=sharing) (also available on our [Resources](resources/#brigade-operations) page).
+The CfA MOU outlines our relationship with our parent organization. After a full Steering Committee review and discussion, the team voted to approve signing of our memorandum of understanding (MOU) with Code for America, with several key revisions proposed. After some negotiation and discussion with CfA to address issues of data privacy and “what if” scenarios, we signed the new 6-month MOU.  [View the PDF](https://drive.google.com/file/d/12sbk7btqWpdqB_OBBDaiYiS2Arx8SJ0w/view?usp=sharing) (also available on our [Resources](/resources/#brigade-operations) page).
 
 ## Discussion: Options for addressing culture change
 


### PR DESCRIPTION
## Description

Closes #243 (replace MOU), #249 (Dec/Jan SC recap), and updates the FPS project description and repo link.

[Screenshot 2022-02-11 at 14-45-01 Steering Committee Recap Dec-Jan](https://user-images.githubusercontent.com/32755410/153680849-902a3791-0566-4dd8-97b8-abd62d76c4ca.png)
