### PR TITLE
fixed wrong link to exploration worksheet

### DIFF
--- a/src/_data/resources-pm.yml
+++ b/src/_data/resources-pm.yml
@@ -5,7 +5,7 @@
  author: OpenOakland
  description: Required to become an OpenOakland project, the exploration worksheet helps teams articulate community needs, ensures impacted voices are reflected in project design, and explores potential unintended consequences.
  format: Google Doc
- link: https://openoakland.org
+ link: https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing
  button-text: Get the Template
  secondaryLink: https://drive.google.com/file/d/1ivtFcFTtXg33paMLCCMkdxKOZ9hpGVJf/view?usp=sharing
  secondaryLinkText: More Context (PDF)


### PR DESCRIPTION
closes #259 

Fixed the link in the Resource's OpenOakland Project Exploration Worksheet to the correct [exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing).
