### PR TITLE
Removing banner

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -1,9 +1,5 @@
 <header class="site-header">
 
-<div style="background-color:alert-danger; width:100%;">
-  {% include home-sections/announcement-warning.html %}
-</div>
-
   <nav class="navbar navbar-expand-lg navbar-light ">
     {%- assign default_paths = site.data.navigation | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}

--- a/src/contact.md
+++ b/src/contact.md
@@ -8,8 +8,7 @@ layout: page
 Get in touch! Your message will be posted to the Steering Committee channel in OpenOakland's Slack group. A volunteer team member will get back to you as soon as possible, so please allow several days for a response.
 
 
-- General inquiries: [steering@openoakland.org](mailto:steering@openoakland.org)
-- Media inquiries: [jess@openoakland.org](mailto:jess@openoakland.org)
+For general inquiries: [steering@openoakland.org](mailto:steering@openoakland.org)
 
 For faster response times, consider [joining us in Slack](https://join.slack.com/t/openoakland/shared_invite/zt-n4d7tx2t-UVIN7a769e4oc9j7PgM3HA) and posting in #oo-steering-committee.
 


### PR DESCRIPTION
* removes the banner announcing meetup pauses which was introduced with #269 
* Takes Jess's email off contact page / removes special handling for media inquiries

### Desktop screenshots
![Screenshot 2022-12-07 9 46 43 PM](https://user-images.githubusercontent.com/1191015/206367488-e8db63e6-3ed6-4aed-9637-7283cd64688f.png)
