### PR TITLE
unhide and fix home-next-event.html

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ permalink: pretty
 #   - vendor/gems/
 #   - vendor/ruby/
 jekyll_get_json:
-  - data: events
+  - data: upcoming
     json: 'https://api.meetup.com/OpenOakland/events?&page=2'
 
 exclude:

--- a/src/_includes/home-sections/home-next-event.html
+++ b/src/_includes/home-sections/home-next-event.html
@@ -1,5 +1,5 @@
 <h2>Upcoming events</h2>
-{% assign next_event = site.data.events[0] %}
+{% assign next_event = site.data.upcoming[0] %}
 
 <div class="card home__event-card">
   <div class="card-header">

--- a/src/index.md
+++ b/src/index.md
@@ -9,8 +9,8 @@ author: OpenOakland
 
 <!--- Section: Next Event -->
 
-<!-- {% include home-sections/home-next-event.html %}
--->
+{% include home-sections/home-next-event.html %}
+
 
 
 


### PR DESCRIPTION
closes #267 

- changed variable name of saved data from Meetup api to prevent data from being overriden
- unhide upcoming event card from home page

### Mobile screenshots
<br>
<img width="318" alt="Screenshot 2023-02-04 at 9 04 09 PM" src="https://user-images.githubusercontent.com/16846028/216802730-1dd3717c-7868-4146-b580-087e74f3cc3a.png">


### Desktop screenshots
<img width="970" alt="Screenshot 2023-02-04 at 9 03 38 PM" src="https://user-images.githubusercontent.com/16846028/216802734-039c95d8-4dca-4e07-9364-a94221105a1c.png">
