### PR TITLE
update calendar page and rename to Events until we get a calendar back

### DIFF
--- a/src/_data/navigation.yml
+++ b/src/_data/navigation.yml
@@ -2,7 +2,7 @@
   path: /
 - title: About Us
   path: about-us.md
-- title: Calendar
+- title: Events
   path: /calendar/
 - title: Contact
   path: contact.md

--- a/src/calendar/calendar.md
+++ b/src/calendar/calendar.md
@@ -1,31 +1,18 @@
 ---
-title: Calendar
+title: Events
 date:  2020-11-07T02:09:11+00:00
 author: OpenOakland
 layout: page
 permalink: /calendar/
 ---
-[Upcoming events](#upcoming-events) \| [Suggest a speaker](#suggest-a-speaker) \| [Past events](#past-events)
 
+## Join us in City Hall
 
-## Join us every Tuesday on Zoom
+We typically meet in-person on the first Tuesday of the month at 6:30pm in Hearing Room 3 (Oakland City Hall). Over time, we'd like to add virtual meetings as well. [Joining our meetup group](https://www.meetup.com/OpenOakland/events/) is the best way to hear about upcoming events.
 
-**6:00-6:30** Intro for newcomers  
-**6:30-8:30** Brigade-wide activities for everyone
+We welcome people of all skill levels and disciplines. Normally, we meet in Oakland City Hall ([directions](https://goo.gl/maps/YTNkpZcb7Sy936w88)). If you need accessibility assistance, please email steering@openoakland.org.
 
-We welcome folks of all skill levels and disciplines. Normally, we meet in Oakland City Hall ([directions](https://goo.gl/maps/YTNkpZcb7Sy936w88)) but we're fully remote during the pandemic. If you need accessibility assistance, please email steering@openoakland.org.
-
-[RSVP on Meetup](https://www.meetup.com/OpenOakland/events/){: .btn .btn-primary }
-
-## Upcoming events
-
-The first Tuesday of each month is Demo Night, when you can see the latest updates from active projects. The third Tuesday of each of month is [Steering Committee](/how-we-work){: .image-caption }, which everyone is welcome to join.
-{: .image-caption }
-
-{% include embed-calendar.html %}
-
-{% include calendar/cal-includes.html %}
-
+[Join Our Meetup Group](https://www.meetup.com/OpenOakland/events/){: .btn .btn-primary }
 
 
 ## Past Events


### PR DESCRIPTION
* remove calendar
* Update information on cadence
* Remove speaker request form

![Screenshot 2023-06-06 9 15 09 PM](https://github.com/openoakland/openoakland.org/assets/1191015/2fb1c928-4921-4bc6-b48d-334a234fe363)
