### PR TITLE
adding mailerlite newsletter embedded form

### DIFF
--- a/src/_includes/mailerlite-newsletter-signup-form.html
+++ b/src/_includes/mailerlite-newsletter-signup-form.html
@@ -1,0 +1,11 @@
+<!-- MailerLite Universal -->
+<script>
+    (function(w,d,e,u,f,l,n){w[f]=w[f]||function(){(w[f].q=w[f].q||[])
+    .push(arguments);},l=d.createElement(e),l.async=1,l.src=u,
+    n=d.getElementsByTagName(e)[0],n.parentNode.insertBefore(l,n);})
+    (window,document,'script','https://assets.mailerlite.com/js/universal.js','ml');
+    ml('account', '268423');
+</script>
+<!-- End MailerLite Universal -->
+
+<div class="ml-embedded" data-form="STT0hz"></div>

--- a/src/newsletter.md
+++ b/src/newsletter.md
@@ -1,4 +1,9 @@
 ---
-title: OpenOakland Newsletter
-redirect_to: http://eepurl.com/db36wj
+title: Newsletter Signup
+date:  2023-06-05T02:09:11+00:00
+author: OpenOakland
+layout: page
+permalink: /newsletter/
 ---
+
+{% include mailerlite-newsletter-signup-form.html %}


### PR DESCRIPTION
Use mailerlite's form builder interface to edit the content / style of this form

Removes mailchimp form since that list is now inactive (we still typically get one signup a week somehow)

![Screenshot 2023-06-06 10 31 29 PM](https://github.com/openoakland/openoakland.org/assets/1191015/4c8fab09-92c7-40e2-aa21-a1f9ad85d309)