### PR TITLE
explicitly specify bundler version for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,8 @@ jobs:
       - run:
           name: Configure Bundler # use bundler version in Gemfile.lock
           command: |
-            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
-            source $BASH_ENV
-            gem install bundler
+            BUNDLER_VERSION=$(tail -1 Gemfile.lock | tr -d " ")
+            gem install bundler -v "$BUNDLER_VERSION"
       - run: bundle install --path vendor/bundle
       - save_cache:
           key: v1-bundle-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Following Colin's lead: https://github.com/caciviclab/odca-jekyll/pull/467