### PR TITLE
Update spring 2026 content: steering committee, projects, and site copy

### DIFF
--- a/src/_data/active_projects.yml
+++ b/src/_data/active_projects.yml
@@ -1,7 +1,7 @@
 -
   name: Democracy Dollars
   website: https://www.oaklandca.gov/topics/democracy-dollars
-  leader: Niels Helvig Thorsen / Kenny Wu
+  leader: Niels Helvig Thorsen
   slack_id: C06470G7HA9
   slack_channel: project-democracy-dollars
   description: Democracy Dollars is a public campaign finance initiative passed by Oakland voters (Measure W) and rolling out for the 2026 election. This team is prototyping a digital experience for the program and recruiting UX designers and researchers!
@@ -16,23 +16,3 @@
   slack_channel: project-oo-website
   description: As the digital face of OpenOakland, our website serves new and existing members, community and government partners, and members of the larger Oakland and civic tech communities. The site was recently migrated from a Wordpress install to a static Jekyll site hosted on AWS. The migration focused primarily on moving the codebase, and we now are working on improving site architecture and visual design. Issues in GutHub marked "Good First Issue" are great for first-timers.
   tech: Jekyll, Kramdown, Bootstrap UI
--
-  name: Open Disclosure Oakland
-  image: opendisclosure_300x233.png
-  website: http://www.opendisclosure.io/
-  repo: https://github.com/caciviclab
-  leader: Mike Ubell, Colin King-Bailey, and Suzanne Doran
-  slack_id: C02GKECTJ
-  slack_channel: project-open-disclosure
-  description: Open Disclosure helps Oaklanders understand the role of money in their local politics. By analyzing mandatory campaign finance disclosures for candidates seeking public office, Open Disclosure presents a user-friendly overview of who is raising money, from where, and how much. Open Disclosure is developed in partnership with the City of Oakland Public Ethics Commission.
-  tech: Jekyll, PostgreSQL
--
-  name: OpenOUSD
-  image: OpenOUSD.png
-  website: https://openousd.org/
-  repo: https://github.com/openoakland/openousd-site
-  leader: John Baldo
-  slack_id: CEDNVVCRG
-  slack_channel: project-open-ousd
-  description: OpenOUSD aims to bring greater transparency to the Oakland Unified School District's central office so that the community can fully participate in discussions about how it can best serve our students. OpenOUSD is a project of OpenOakland, a volunteer run group with the mission of increasing access to government through technology. OpenOUSD receives no public or private funds and is not an official OUSD website.
-  tech: Gatsby, Postgres, Node.js

--- a/src/_data/incubating_projects.yml
+++ b/src/_data/incubating_projects.yml
@@ -1,5 +1,5 @@
 -
-  name: CityCamp Oakland 2024
+  name: CityCamp Oakland 2026
   established: 2013
   website:
   repo:

--- a/src/_data/recruiting_projects.yml
+++ b/src/_data/recruiting_projects.yml
@@ -1,0 +1,33 @@
+-
+  name: Open Disclosure Oakland
+  description: Open Disclosure helps Oaklanders understand the role of money in their local politics. By analyzing mandatory campaign finance disclosures for candidates seeking public office, Open Disclosure presents a user-friendly overview of who is raising money, from where, and how much. Open Disclosure is developed in partnership with the City of Oakland Public Ethics Commission.
+  image: opendisclosure_300x233.png
+  website: http://www.opendisclosure.io/
+  repo: https://github.com/caciviclab
+  tech: Jekyll, PostgreSQL
+  leader: Mike Ubell
+  slack_id: C02GKECTJ
+  slack_channel: project-open-disclosure
+  recruiting: Front End Developers
+-
+  name: Brightwayz
+  description: Brightwayz is a mobile-first platform that helps people quickly find shelters, food banks, and community services — and submit a request for help in minutes. Staff at partner organisations get a single dashboard to manage cases, track referrals, and communicate with clients. An AI layer is coming that will summarise intake forms, recommend services, and support multiple languages.
+  image:
+  website:
+  repo:
+  tech: TBD
+  leader: Abdel Errami
+  slack_id:
+  slack_channel: brightwayz-community-channel
+  recruiting: User Researchers, Project/Product Managers
+-
+  name: EVOAK
+  description: 'EVOAK! (pronounced: evoke) has gathered West Oakland community asset data as part of the CalTrans Vision 980 project to re-imagine the I-980 corridor but needs help designing a digital interface that makes the data actionable for land developers, City approvers, service providers, others.'
+  image:
+  website:
+  repo:
+  tech: TBD
+  leader: Dani Platt
+  slack_id:
+  slack_channel: project-evoak
+  recruiting: Product Managers

--- a/src/_includes/project.html
+++ b/src/_includes/project.html
@@ -42,6 +42,11 @@
               rel="noopener noreferrer">#{{ project.slack_channel }}</a></p>
           {% endif %}
 
+          {% if project.recruiting %}
+          <p class="card-text"><small><b>Now Recruiting</b></small><br/>
+          {{ project.recruiting }}</p>
+          {% endif %}
+
         </div>
       </div>
 

--- a/src/_includes/steering-committee.html
+++ b/src/_includes/steering-committee.html
@@ -1,11 +1,10 @@
 <div class="container">
 
-<!-- First row -->
+<!-- Row 1: Leads -->
 
   <div class="row">
 
     <div class="col-sm-4">
-      <h5>Treasurer/Recorder</h5>
       <div>
         <img
           class="steeering-committee-image"
@@ -13,14 +12,111 @@
           src="/assets/images/OpenOakland-logo-favicon.png"
         />
         <p class="image-caption" style="font-weight:bold;">
-          Sean Martinez<br/>
-          <span class="image-caption" style="font-weight:normal;">@Sean in Slack</span>
+          Mike Ubell (Lead)<br/>
+          <span class="image-caption" style="font-weight:normal;">@Mike in Slack</span>
         </p>
       </div>
     </div>
 
     <div class="col-sm-4">
-      <h5>Community Organizer</h5>
+      <div>
+        <img
+          class="steeering-committee-image"
+          alt="OpenOakland logo"
+          src="/assets/images/OpenOakland-logo-favicon.png"
+        />
+        <p class="image-caption" style="font-weight:bold;">
+          Danielle Platt (Lead)<br/>
+          <span class="image-caption" style="font-weight:normal;">@Dani in Slack</span>
+        </p>
+      </div>
+    </div>
+
+    <div class="col-sm-4">
+      <div>
+        <img
+          class="steeering-committee-image"
+          alt="OpenOakland logo"
+          src="/assets/images/OpenOakland-logo-favicon.png"
+        />
+        <p class="image-caption" style="font-weight:bold;">
+          Cristy Rowley (Lead)<br/>
+          <span class="image-caption" style="font-weight:normal;">@Cristy in Slack</span>
+        </p>
+      </div>
+    </div>
+
+  </div>
+
+
+<!-- Row 2 -->
+
+  <div class="row">
+
+    <div class="col-sm-4">
+      <div>
+        <img
+          class="steeering-committee-image"
+          alt="OpenOakland logo"
+          src="/assets/images/OpenOakland-logo-favicon.png"
+        />
+        <p class="image-caption" style="font-weight:bold;">
+          Toni Aguilar<br/>
+          <span class="image-caption" style="font-weight:normal;">@Toni in Slack</span>
+        </p>
+      </div>
+    </div>
+
+    <div class="col-sm-4">
+      <div>
+        <img
+          class="steeering-committee-image"
+          alt="OpenOakland logo"
+          src="/assets/images/OpenOakland-logo-favicon.png"
+        />
+        <p class="image-caption" style="font-weight:bold;">
+          Felicia Betancourt<br/>
+          <span class="image-caption" style="font-weight:normal;">@Felicia in Slack</span>
+        </p>
+      </div>
+    </div>
+
+    <div class="col-sm-4">
+      <div>
+        <img
+          class="steeering-committee-image"
+          alt="OpenOakland logo"
+          src="/assets/images/OpenOakland-logo-favicon.png"
+        />
+        <p class="image-caption" style="font-weight:bold;">
+          Abdel Erami<br/>
+          <span class="image-caption" style="font-weight:normal;">@Abdel in Slack</span>
+        </p>
+      </div>
+    </div>
+
+  </div>
+
+
+<!-- Row 3 -->
+
+  <div class="row">
+
+    <div class="col-sm-4">
+      <div>
+        <img
+          class="steeering-committee-image"
+          alt="OpenOakland logo"
+          src="/assets/images/OpenOakland-logo-favicon.png"
+        />
+        <p class="image-caption" style="font-weight:bold;">
+          Blaise Harrison<br/>
+          <span class="image-caption" style="font-weight:normal;">@Blaise in Slack</span>
+        </p>
+      </div>
+    </div>
+
+    <div class="col-sm-4">
       <div>
         <img
           class="steeering-committee-image"
@@ -34,59 +130,12 @@
       </div>
     </div>
 
-    <div class="col-sm-4">
-      <h5>Communications Lead</h5>
-      <div>
-        <img
-        class="steeering-committee-image"
-        alt="OpenOakland logo"
-        src="/assets/images/OpenOakland-logo-favicon.png"
-      />
-      <p class="image-caption" style="font-weight:bold;">
-        Jess Sand<br/>
-        <span class="image-caption" style="font-weight:normal;">@Jess in Slack</span>
-      </p>
-      </div>
-    </div>
-
   </div>
 
-
-<!-- Second row -->
-
-  <div class="row">
-
-    <div class="col-sm-4">
-      <h5>Hack Night Lead</h5>
-      <div>
-        <img
-          class="steeering-committee-image"
-          alt="OpenOakland logo"
-          src="/assets/images/OpenOakland-logo-favicon.png"
-        />
-        <p class="image-caption" style="font-weight:bold;">Open<br/>
-        <span class="image-caption" style="font-weight:normal;">Visit @oo-steering-committee in Slack if you're interested in emceeing.</span>
-        </p>
-      </div>
+  <div class="row" style="margin-top:1rem;">
+    <div class="col-sm-12">
+      <p>Contact us at <a href="mailto:steering@openoakland.org">steering@openoakland.org</a></p>
     </div>
-
-    <div class="col-sm-4">
-      <div>
-        <h5>Steering Committee Chair</h5>
-        <div>
-          <img
-            class="steeering-committee-image"
-            alt="OpenOakland logo"
-            src="/assets/images/OpenOakland-logo-favicon.png"
-          />
-        <p class="image-caption" style="font-weight:bold;">
-          Sean Martinez<br/>
-          <span class="image-caption" style="font-weight:normal;">@Sean in Slack</span>
-        </p>
-        </div>
-      </div>
-    </div>
-
   </div>
 
 </div>

--- a/src/_includes/steering-faq.html
+++ b/src/_includes/steering-faq.html
@@ -101,7 +101,7 @@
           <h4>Where is the upcoming agenda?</h4>
           <p>The agenda is pinned to the <a href="https://app.slack.com/client/T02FEGG84/C02FG2BUX">#oo-steering-committee channel</a> in Slack.</p>
           <h4>How are Steering Committee decisions communicated out?</h4>
-          <p>The elect team will attempt to summarize major meeting items within a couple of days in the #oo-general channel in Slack, as well as at the following Hack Night and in the <a href="/newsletter">brigade newsletter</a>.</p>
+          <p>The elect team will attempt to summarize major meeting items within a couple of days in the #oo-general channel in Slack, as well as at the following Monthly Meeting and in the <a href="/newsletter">brigade newsletter</a>.</p>
           <h4>How to contact the Steering Committee</h4>
           <p>To contact the steering committee, email <a href="mailto:steering@openoakland.org">steering@openoakland.org</a> or post in the <a href="https://app.slack.com/client/T02FEGG84/C02FG2BUX">#oo-steering-committee channel</a> in Slack.</p>
         </div>

--- a/src/_resources/2017-03-29-how-to-be-an-openoakland-project.md
+++ b/src/_resources/2017-03-29-how-to-be-an-openoakland-project.md
@@ -11,7 +11,7 @@ layout: page
 - Demo nights are the first Tuesday of every month.
 - Physical presence is not required.
 - Projects may: present remotely, record a presentation or post a publication (blog, etc).
-- Ask Hack Night Lead if you'd like to update in a different way. We're open!
+- Ask Monthly Meeting Lead if you'd like to update in a different way. We're open!
 - _**All projects must be Open Source and <a href="https://opensource.org/licenses/mit-license.php" target="_blank" rel="noopener">licensed using the MIT open source license</a> to be considered an OpenOakland project.**_
 
 #### Gaining Representation on the Steering Committee
@@ -22,13 +22,13 @@ layout: page
 
 #### Off-boarding Projects
 
-- Occasionally, the Hack Night Lead will recommend that the Steering Committee vote to remove projects from the active list if they have not met the active project requirements. A simple majority is needed to remove.
+- Occasionally, the Monthly Meeting Lead will recommend that the Steering Committee vote to remove projects from the active list if they have not met the active project requirements. A simple majority is needed to remove.
 - Once removed, the project will be removed from the OpenOakland website, lose Steering Committee representation and potentially lose OpenOakland resources if they are needed for active projects.
 - A project can reactivate at any time!
 
-#### Role of the Hack Night Lead
+#### Role of the Monthly Meeting Lead
 
-- Hack Night Lead is responsible for guiding projects through this process and supporting projects with resources they need to make progress.
+- Monthly Meeting Lead is responsible for guiding projects through this process and supporting projects with resources they need to make progress.
 
 ---
 

--- a/src/about-us.md
+++ b/src/about-us.md
@@ -47,13 +47,13 @@ Current Steering Committee members:
 
 ## Get involved
 
-- **Join us at Hack Night.**  
+- **Join us at our Monthly Meeting.**  
     Every first Tuesday from 6:30-9:00pm PST, we meet in City Hall but are working remotely during the coronavirus pandemic). After intros, we break into project teams for deeper collaboration. Don't be shy about joining in; we're friendly folk. [RSVP on Meetup](https://www.meetup.com/OpenOakland/).
 
 - **Join us on Slack.**  
-    [Join us on Slack](https://join.slack.com/t/openoakland/shared_invite/zt-n4d7tx2t-UVIN7a769e4oc9j7PgM3HA) and introduce yourself in #oo-meet-and-greet (see our [OpenOakland Slack Guide](https://docs.google.com/document/d/1VWZQ_3ehP5j0IOTY0nJClvQPll3ivSkuAdh5YsOhO_U/edit?usp=sharing) for help). We look forward to meeting you!
+    [Join us on Slack](https://join.slack.com/t/openoakland/shared_invite/zt-n4d7tx2t-UVIN7a769e4oc9j7PgM3HA) and introduce yourself in #oo-meet-and-greet. We look forward to meeting you!
 
 - **Contribute to an existing project.**  
-    Check out our [active projects](/projects/). You're welcome to contact project leads directly or jump into their Github repos but if you're not a coder or are unsure how you might contribute, we suggest attending Hack Night to get to know our project teams.
+    Check out our [active projects](/projects/). You're welcome to contact project leads directly or jump into their Github repos but if you're not a coder or are unsure how you might contribute, we suggest attending our Monthly Meeting to get to know our project teams.
 
 **We hope to see you soon!**

--- a/src/calendar/calendar.md
+++ b/src/calendar/calendar.md
@@ -6,9 +6,9 @@ layout: page
 permalink: /calendar/
 ---
 
-## Join us in City Hall
+## Join us at City Hall
 
-We typically meet in-person on the first Tuesday of the month at 6:30pm in Hearing Room 3 ([Oakland City Hall](https://goo.gl/maps/YTNkpZcb7Sy936w88)). Over time, we'd like to add virtual meetings as well. [Joining our meetup group](https://www.meetup.com/OpenOakland/events/) is the best way to hear about upcoming events.
+We typically meet in-person on the first Tuesday of the month at 6:30pm in Hearing Room 3 ([Oakland City Hall](https://goo.gl/maps/YTNkpZcb7Sy936w88)). [Joining our meetup group](https://www.meetup.com/OpenOakland/events/) is the best way to hear about upcoming events.
 
 We welcome people of all skill levels and disciplines. If you need accessibility assistance, please email steering@openoakland.org.
 

--- a/src/projects.md
+++ b/src/projects.md
@@ -8,6 +8,7 @@ badges:
   brigade ops: 'primary'
   active: 'success'
   incubating: 'info'
+  recruiting: 'danger'
   idle: 'secondary'
   delivered: 'dark'
   decommissioned: 'warning'
@@ -20,6 +21,12 @@ Browse the projects below to see what we're currently working on. You can filter
 
 <project-filter>
   <div class="project-filter__toolbar"></div>
+
+  <!-- Recruiting -->
+  {% for project in site.data.recruiting_projects %}
+  {% assign status = 'recruiting' %}
+  {% include project.html %}
+  {% endfor %}
 
   <!-- Active -->
   {% for project in site.data.active_projects %}
@@ -66,13 +73,17 @@ These projects are actively supported by a core team of OpenOakland volunteers. 
 
 Incubating projects are in the exploratory or start-up phase before becoming an official OpenOakland project. To be listed as an incubating project, ideas must have a draft [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) completed, an acting lead shepherding the idea, and be actively recruiting collaborators. Placement on the website is at the discretion of the Steering Committee.
 
+### <span class="badge badge-{{ page.badges['recruiting'] }}">Recruiting</span>
+
+These projects are currently looking for volunteers. Connect with the project lead on Slack to learn more.
+
 ### <span class="badge badge-{{ page.badges['brigade ops'] }}">Brigade ops</span>
 
 These projects support OpenOakland's operations. Like <span class="badge badge-{{ page.badges['active'] }}">Active</span> and <span class="badge badge-{{ page.badges['incubating'] }}">Incubating</span> projects, they are [open to volunteer contributions](#get-involved).
 
 ### <span class="badge badge-{{ page.badges['idle'] }}">Idle</span>
 
-Sometimes projects go quiet when the core team gets too busy or disbands. If you'd like to resume or adapt one of these, submit a [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) at an upcoming Hack Night or in Slack's #oo-steering-committee channel.
+Sometimes projects go quiet when the core team gets too busy or disbands. If you'd like to resume or adapt one of these, submit a [project exploration worksheet](https://docs.google.com/document/d/1k24P9JiAUEzJLPFRDjVh7aRZexax6NUhfPFLSI3R80M/edit?usp=sharing) at our Monthly Meeting or in Slack's #oo-steering-committee channel.
 
 ### <span class="badge badge-{{ page.badges['delivered'] }}">Delivered</span>
 
@@ -90,7 +101,7 @@ These are projects the Steering Committee has formally reviewed and deemed no lo
 There are several ways to contribute to an existing project:
 
 - Join us for our Tuesday [meetups](https://www.meetup.com/OpenOakland/events/) to connect with the project team.
-- Join our [Slack workspace](https://join.slack.com/t/openoakland/shared_invite/zt-n4d7tx2t-UVIN7a769e4oc9j7PgM3HA) and introduce yourself in the project's channel listed in the description (see our [OpenOakland Slack Guide](https://docs.google.com/document/d/1VWZQ_3ehP5j0IOTY0nJClvQPll3ivSkuAdh5YsOhO_U/edit?usp=sharing) for help).
+- Join our [Slack workspace](https://join.slack.com/t/openoakland/shared_invite/zt-n4d7tx2t-UVIN7a769e4oc9j7PgM3HA) and introduce yourself in the project's channel listed in the description.
 - Email [steering@openoakland.org](mailto:steering@openoakland.org) with any questions or feedback.
 
 
@@ -129,6 +140,6 @@ Projects must demonstrate alignment to OpenOakland’s mission and values. Some 
 In the spirit of continuous improvement and self-reflection, we welcome any and all feedback on OpenOakland projects past and present, as well as the overall project management process. Ways you can share your input include:
 
 - Open an issue in the project's GitHub repository (listed in the project description).
-- Join the project's channel in our [Slack workspace](https://join.slack.com/t/openoakland/shared_invite/zt-n4d7tx2t-UVIN7a769e4oc9j7PgM3HA) and introduce yourself (see our [OpenOakland Slack Guide](https://docs.google.com/document/d/1VWZQ_3ehP5j0IOTY0nJClvQPll3ivSkuAdh5YsOhO_U/edit?usp=sharing) for help).
-- Join our next [Hack Night](https://www.meetup.com/OpenOakland/events/) and meet the team.
+- Join the project's channel in our [Slack workspace](https://join.slack.com/t/openoakland/shared_invite/zt-n4d7tx2t-UVIN7a769e4oc9j7PgM3HA) and introduce yourself.
+- Join our next [Monthly Meeting](https://www.meetup.com/OpenOakland/events/) and meet the team.
 - Email our [Steering Committee](mailto:steering@openoakland.org) with your input.


### PR DESCRIPTION
- Update steering committee members with leads and contact info
- Add Recruiting project status with Brightwayz, EVOAK, Open Disclosure
- Rename Hack Night to Monthly Meeting throughout
- Remove Slack Guide references
- Update CityCamp Oakland to 2026, remove OpenOUSD
- Fix City Hall copy and remove outdated virtual meeting note

